### PR TITLE
relative entropy pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+data
+config.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,164 @@
-data
-config.py
+relative-entropy/data
+relative-entropy/config.py
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+five_epoch_jan23/distilgpt2
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -7,3 +7,196 @@ Each directory description
 
 * Task B: 
 
+
+## Relative entropy pipeline
+
+All code is in the [relative-entropy](./relative-entropy/) directory. There is a script that will run the full pipeline: [run_entropy_pipeline.sh](./relative-entropy/run_entropy_pipeline.sh) (see steps 0 and 1 below before running it). The section below describes each step.
+
+
+### Steps
+
+0. Data: This pipeline assumes that the following files are in one directory:
+    * clp24_all_messages.csv: This contains all messages from the dataset, including data from the *no risk* users. Prepare it to contain the `label` column with the post authors' risk levels and the `by` (which annotator group) column. For *no risk* users, set the label to "No".
+    * clp24_all_messages_test.csv: The messages of the users designated for the test set for the shared task.
+    * clp24_all_messages_train.csv: The messages of users not in the test set
+    * clp24_SW_messages_sent_tokenized.csv: Sentences from each post in r/SuicideWatch (nltk.sent_tokenize applied to messages).
+
+1. Create a file **config.py** with these contents:
+
+    ```python
+    '''config.py'''
+    DATADIR = # string pointing to the path of the clpsych24 shared task data, e.g., "/data/clp24/" 
+    MODELDIR = # string pointing to a path to a directory where you want to save the finetuning output, e.g., "/data/clp24/finetune-output/"
+    ```
+
+2. Prepare dataset for language modeling scripts
+    ```bash
+    python prepare_data.py
+    ```
+    * The script will create two files:
+        1) DATADIR/all_labels_messages_train.csv
+        2) DATADIR/all_labels_messages_test.csv
+    * Change where to save the files in the two lines after the imports, if you like.
+    * Change the number of no risk posts to include in the test set, if you like. We go with a small sample.
+
+3. Finetune a language model on a group of CLPsych users based on risk level.
+
+    * You are required to specify a group to finetune on. All options follow the format `{Risk level}_risk_{Subreddit set}`. *Risk level* can be no, low, moderate, high, or any (includes low, moderate, and high, but not no risk). *Subreddit set* can be sw (SuicideWatch posts only) or all (all posts by the users in the risk level group)
+
+    
+    * Example:
+        ```bash
+        # example
+        python finetune.py --train_group high_risk_sw --model_output_dir data/model_output
+        ```
+    
+    * Usage:
+        ```
+        Usage: 
+        python finetune.py [-h] -g {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all} [-tr ALL_LABELS_MESSAGES_TRAIN] [-d MODEL_OUTPUT_DIR] [-k] [--logging_dir LOGGING_DIR] [--device DEVICE] [-m {distilgpt2}] [-e NUM_EPOCHS] [-lr LEARNING_RATE] [-wd WEIGHT_DECAY] [-ss SAVE_STRATEGY] [-es EVAL_STRATEGY] [--logging_steps LOGGING_STEPS] [--hidden_dropout_prob HIDDEN_DROPOUT_PROB] [--train_proportion TRAIN_PROPORTION]
+
+        Options
+            -h, --help
+            -g, --train_group {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all}
+            -tr ALL_LABELS_MESSAGES_TRAIN, --all_labels_messages_train ALL_LABELS_MESSAGES_TRAIN
+                                    Path to training data file.
+            -d, --model_output_dir MODEL_OUTPUT_DIR
+                                    Directory for saving the model checkpoints. They will be saved at [args.dir]/[args.train_group]. Recommended to make this unique to your experiment.
+            -k, --keep_annotations
+                                    Pass in -k if you want to include the posts that we annotated internally.
+            --logging_dir LOGGING_DIR
+                                    Path to a logging dir if you don't want to use the default.
+            --device DEVICE
+            -m, --base_lm {distilgpt2}
+                                    Name of pre-trained language model you want to finetune.
+            -e, --num_epochs NUM_EPOCHS
+            -lr LEARNING_RATE, --learning_rate LEARNING_RATE
+            -wd, --weight_decay WEIGHT_DECAY
+            -ss, --save_strategy SAVE_STRATEGY
+            -es, --eval_strategy EVAL_STRATEGY
+            --logging_steps LOGGING_STEPS
+                                    Number of update steps between logs
+            --hidden_dropout_prob HIDDEN_DROPOUT_PROB
+                                    Dropout
+            --train_proportion TRAIN_PROPORTION
+                                    Proportion of data to use for train, the rest will be used for eval.
+        ```
+
+4. (Optional) Plot losses of the finetuned language models.
+    ```bash
+    python plot_loss.py 
+    ```
+
+    ```
+    Options:
+        -h, --help            show this help message and exit
+        -lm LM_TO_PLOT [LM_TO_PLOT ...], --lm_to_plot LM_TO_PLOT [LM_TO_PLOT ...]
+                                Name of the language models you want to plot (i.e. the 'train group'). If passing in nothing, it will do all found LMs in --model_dir path.
+        -d, --model_dir MODEL_DIR 
+                                Directory where the lms are. Defaults to MODELDIR specified in config.py.
+        -o, --plot_path PLOT_PATH
+                                Directory where you want to save the plot images. Defaults to MODELDIR/_loss_plots.
+    ```
+
+
+5. Compute token entropies using one group's language model on another group's test data.
+
+    TODO: optimize implementation, current implementation is inefficient
+
+    Example:
+
+    ```bash
+    # example
+
+    # compute losses from each group model on their own test data
+    python compute_entropy.py --train_group any_risk_sw --test_group any_risk_sw;
+
+    # compute losses from each group model on any risk data
+    python compute_entropy.py --train_group no_risk_sw --test_group any_risk_sw;
+    ```
+
+    ```
+    Options:
+        -h, --help            show this help message and exit
+        -tr {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all}, --train_group {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all}
+                                This specifies the language model that we'll use to compute losses.
+        -te {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all,annotations}, --test_group {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all,annotations}
+                                This specifies the data that the language model will be run on for losses.
+        -d MODEL_OUTPUT_DIR, --model_output_dir MODEL_OUTPUT_DIR
+                                Directory where the finetuned models are saved.
+        -o TOKEN_ENTROPIES_DIR, --token_entropies_dir TOKEN_ENTROPIES_DIR
+                                Directory path where you want to save the token entropies.
+        --all_labels_messages_train ALL_LABELS_MESSAGES_TRAIN
+                                Path to training data file.
+        --all_labels_messages_test ALL_LABELS_MESSAGES_TEST
+                                Path to test data file.
+        -m {distilgpt2,lsanochkin/deberta-large-feedback,microsoft/deberta-base}, --base_lm {distilgpt2,lsanochkin/deberta-large-feedback,microsoft/deberta-base}
+        -lm {lm,mlm}, --lm_type {lm,mlm}
+                                lm: CausalLM | mlm: MaskedLM. Not implemented for mlm yet.
+        --device DEVICE
+        -sw SW_SIZE, --sw_size SW_SIZE
+                                Context window size preceding target token.
+        --checkpoint_selection CHECKPOINT_SELECTION
+                                Strategy for choosing the model checkpoint to load. Use a) min_eval_loss if you want to choose based on the minimum loss on the val set during training, b) last to use the last checkpoint, or c) a path to
+                                the checkpoint directory, e.g., model_dir/train_group/checkpoint-1000.
+    ```
+
+6. Map token entropies to sentences. Script aggregates the token entropies at sentence level. Output file by default is {ARGS.test_group}_sentence_entropies.json.
+
+    ```bash
+    python sentence_entropy.py
+    ```
+
+    ```
+    Options:
+        -h, --help            show this help message and exit
+        -dir TOKEN_ENTROPIES_DIR, --token_entropies_dir TOKEN_ENTROPIES_DIR
+                                Directory where you have the token entropies saved.
+        -o ARGS.OUTDIR, --ARGS.outdir ARGS.OUTDIR
+                                Directory where you want to save the sentence entropies.
+        --all_messages ALL_MESSAGES
+                                Path to test data file.
+        -st SENT_TOKENIZED_FILE, --sent_tokenized_file SENT_TOKENIZED_FILE
+                                Path to the data broken into sentences.
+        -te {any_risk_sw,annotations}, --test_group {any_risk_sw,annotations}
+                                This specifies the data that the language model will be run on for losses.
+        -s, --save_intermediate_values
+                                Pass in if you want intermediate values to be written to a file.
+    ```
+
+7. Explore span selection policies and write submission file with chosen policy. This step may involve your manual changes to the script to adjust your policies or create new ones, but code is written there that will output samples based on your policies.
+
+    ```bash
+    python span_selection.py # run with -w if you want to write submission files with the policies implemented in the script.
+    ```
+
+8. (optional) Use the compare_systems.py script to compare the highlighted evidence per user from two systems.
+
+    ```bash
+    # example
+    python compare_systems.py -a max_arch_score_70_submission -b prod_max_arc_ent_ac_70_submission
+    ```
+
+    ```
+    Options:
+        -h, --help            show this help message and exit
+        -s SAVE_DF, --save_df SAVE_DF
+                                Pass in a path to save the df with all the intermediate and final score values.
+        -arc ARCHETYPES_SENT_FILE, --archetypes_sent_file ARCHETYPES_SENT_FILE
+                                Path to archetypes sentences file.
+        -dir SENTENCE_ENTROPY_DIR, --sentence_entropy_dir SENTENCE_ENTROPY_DIR
+                                Path to directory that has the sentence entropy files.
+        -te {any_risk_sw,annotations}, --test_group {any_risk_sw,annotations}
+                                This specifies if we're using the internal annotations or the task submission data data.
+        -df SENT_DF_PATH, --sent_df_path SENT_DF_PATH
+                                Path to sentence entropies file. This is an alternative to passing in --sentence_entropy_dir and --test_group.
+        -p PERCENTILE_THRESHOLD, --percentile_threshold PERCENTILE_THRESHOLD
+        -o SUBMISSION_FILE_PATH, --submission_file_path SUBMISSION_FILE_PATH
+        -ml MAX_OUTPUT_LEN, --max_output_len MAX_OUTPUT_LEN
+        --num_posts_to_show NUM_POSTS_TO_SHOW
+        --n_factors N_FACTORS
+        -w, --write
+    ```
+
+9. TODO: (optional) Make latex visual of highlighted spans
+    

--- a/relative-entropy/README.md
+++ b/relative-entropy/README.md
@@ -1,0 +1,192 @@
+## Relative entropy pipeline
+
+All code is in the [relative-entropy](./relative-entropy/) directory. There is a script that will run the full pipeline: [run_entropy_pipeline.sh](./relative-entropy/run_entropy_pipeline.sh) (see steps 0 and 1 below before running it). The section below describes each step.
+
+
+### Steps
+
+0. Data: This pipeline assumes that the following files are in one directory:
+    * clp24_all_messages.csv: This contains all messages from the dataset, including data from the *no risk* users. Prepare it to contain the `label` column with the post authors' risk levels and the `by` (which annotator group) column. For *no risk* users, set the label to "No".
+    * clp24_all_messages_test.csv: The messages of the users designated for the test set for the shared task.
+    * clp24_all_messages_train.csv: The messages of users not in the test set
+    * clp24_SW_messages_sent_tokenized.csv: Sentences from each post in r/SuicideWatch (nltk.sent_tokenize applied to messages).
+
+1. Create a file **config.py** with these contents:
+
+    ```python
+    '''config.py'''
+    DATADIR = # string pointing to the path of the clpsych24 shared task data, e.g., "/data/clp24/" 
+    MODELDIR = # string pointing to a path to a directory where you want to save the finetuning output, e.g., "/data/clp24/finetune-output/"
+    ```
+
+2. Prepare dataset for language modeling scripts
+    ```bash
+    python prepare_data.py
+    ```
+    * The script will create two files:
+        1) DATADIR/all_labels_messages_train.csv
+        2) DATADIR/all_labels_messages_test.csv
+    * Change where to save the files in the two lines after the imports, if you like.
+    * Change the number of no risk posts to include in the test set, if you like. We go with a small sample.
+
+3. Finetune a language model on a group of CLPsych users based on risk level.
+
+    * You are required to specify a group to finetune on. All options follow the format `{Risk level}_risk_{Subreddit set}`. *Risk level* can be no, low, moderate, high, or any (includes low, moderate, and high, but not no risk). *Subreddit set* can be sw (SuicideWatch posts only) or all (all posts by the users in the risk level group)
+
+    
+    * Example:
+        ```bash
+        # example
+        python finetune.py --train_group high_risk_sw --model_output_dir data/model_output
+        ```
+    
+    * Usage:
+        ```
+        Usage: 
+        python finetune.py [-h] -g {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all} [-tr ALL_LABELS_MESSAGES_TRAIN] [-d MODEL_OUTPUT_DIR] [-k] [--logging_dir LOGGING_DIR] [--device DEVICE] [-m {distilgpt2}] [-e NUM_EPOCHS] [-lr LEARNING_RATE] [-wd WEIGHT_DECAY] [-ss SAVE_STRATEGY] [-es EVAL_STRATEGY] [--logging_steps LOGGING_STEPS] [--hidden_dropout_prob HIDDEN_DROPOUT_PROB] [--train_proportion TRAIN_PROPORTION]
+
+        Options
+            -h, --help
+            -g, --train_group {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all}
+            -tr ALL_LABELS_MESSAGES_TRAIN, --all_labels_messages_train ALL_LABELS_MESSAGES_TRAIN
+                                    Path to training data file.
+            -d, --model_output_dir MODEL_OUTPUT_DIR
+                                    Directory for saving the model checkpoints. They will be saved at [args.dir]/[args.train_group]. Recommended to make this unique to your experiment.
+            -k, --keep_annotations
+                                    Pass in -k if you want to include the posts that we annotated internally.
+            --logging_dir LOGGING_DIR
+                                    Path to a logging dir if you don't want to use the default.
+            --device DEVICE
+            -m, --base_lm {distilgpt2}
+                                    Name of pre-trained language model you want to finetune.
+            -e, --num_epochs NUM_EPOCHS
+            -lr LEARNING_RATE, --learning_rate LEARNING_RATE
+            -wd, --weight_decay WEIGHT_DECAY
+            -ss, --save_strategy SAVE_STRATEGY
+            -es, --eval_strategy EVAL_STRATEGY
+            --logging_steps LOGGING_STEPS
+                                    Number of update steps between logs
+            --hidden_dropout_prob HIDDEN_DROPOUT_PROB
+                                    Dropout
+            --train_proportion TRAIN_PROPORTION
+                                    Proportion of data to use for train, the rest will be used for eval.
+        ```
+
+4. (Optional) Plot losses of the finetuned language models.
+    ```bash
+    python plot_loss.py 
+    ```
+
+    ```
+    Options:
+        -h, --help            show this help message and exit
+        -lm LM_TO_PLOT [LM_TO_PLOT ...], --lm_to_plot LM_TO_PLOT [LM_TO_PLOT ...]
+                                Name of the language models you want to plot (i.e. the 'train group'). If passing in nothing, it will do all found LMs in --model_dir path.
+        -d, --model_dir MODEL_DIR 
+                                Directory where the lms are. Defaults to MODELDIR specified in config.py.
+        -o, --plot_path PLOT_PATH
+                                Directory where you want to save the plot images. Defaults to MODELDIR/_loss_plots.
+    ```
+
+
+5. Compute token entropies using one group's language model on another group's test data.
+
+    TODO: optimize implementation, current implementation is inefficient
+
+    Example:
+
+    ```bash
+    # example
+
+    # compute losses from each group model on their own test data
+    python compute_entropy.py --train_group any_risk_sw --test_group any_risk_sw;
+
+    # compute losses from each group model on any risk data
+    python compute_entropy.py --train_group no_risk_sw --test_group any_risk_sw;
+    ```
+
+    ```
+    Options:
+        -h, --help            show this help message and exit
+        -tr {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all}, --train_group {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all}
+                                This specifies the language model that we'll use to compute losses.
+        -te {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all,annotations}, --test_group {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all,annotations}
+                                This specifies the data that the language model will be run on for losses.
+        -d MODEL_OUTPUT_DIR, --model_output_dir MODEL_OUTPUT_DIR
+                                Directory where the finetuned models are saved.
+        -o TOKEN_ENTROPIES_DIR, --token_entropies_dir TOKEN_ENTROPIES_DIR
+                                Directory path where you want to save the token entropies.
+        --all_labels_messages_train ALL_LABELS_MESSAGES_TRAIN
+                                Path to training data file.
+        --all_labels_messages_test ALL_LABELS_MESSAGES_TEST
+                                Path to test data file.
+        -m {distilgpt2,lsanochkin/deberta-large-feedback,microsoft/deberta-base}, --base_lm {distilgpt2,lsanochkin/deberta-large-feedback,microsoft/deberta-base}
+        -lm {lm,mlm}, --lm_type {lm,mlm}
+                                lm: CausalLM | mlm: MaskedLM. Not implemented for mlm yet.
+        --device DEVICE
+        -sw SW_SIZE, --sw_size SW_SIZE
+                                Context window size preceding target token.
+        --checkpoint_selection CHECKPOINT_SELECTION
+                                Strategy for choosing the model checkpoint to load. Use a) min_eval_loss if you want to choose based on the minimum loss on the val set during training, b) last to use the last checkpoint, or c) a path to
+                                the checkpoint directory, e.g., model_dir/train_group/checkpoint-1000.
+    ```
+
+6. Map token entropies to sentences. Script aggregates the token entropies at sentence level. Output file by default is {ARGS.test_group}_sentence_entropies.json.
+
+    ```bash
+    python sentence_entropy.py
+    ```
+
+    ```
+    Options:
+        -h, --help            show this help message and exit
+        -dir TOKEN_ENTROPIES_DIR, --token_entropies_dir TOKEN_ENTROPIES_DIR
+                                Directory where you have the token entropies saved.
+        -o ARGS.OUTDIR, --ARGS.outdir ARGS.OUTDIR
+                                Directory where you want to save the sentence entropies.
+        --all_messages ALL_MESSAGES
+                                Path to test data file.
+        -st SENT_TOKENIZED_FILE, --sent_tokenized_file SENT_TOKENIZED_FILE
+                                Path to the data broken into sentences.
+        -te {any_risk_sw,annotations}, --test_group {any_risk_sw,annotations}
+                                This specifies the data that the language model will be run on for losses.
+        -s, --save_intermediate_values
+                                Pass in if you want intermediate values to be written to a file.
+    ```
+
+7. Explore span selection policies and write submission file with chosen policy. This step may involve your manual changes to the script to adjust your policies or create new ones, but code is written there that will output samples based on your policies.
+
+    ```bash
+    python span_selection.py # run with -w if you want to write submission files with the policies implemented in the script.
+    ```
+
+8. (optional) Use the compare_systems.py script to compare the highlighted evidence per user from two systems.
+
+    ```bash
+    # example
+    python compare_systems.py -a max_arch_score_70_submission -b prod_max_arc_ent_ac_70_submission
+    ```
+
+    ```
+    Options:
+        -h, --help            show this help message and exit
+        -s SAVE_DF, --save_df SAVE_DF
+                                Pass in a path to save the df with all the intermediate and final score values.
+        -arc ARCHETYPES_SENT_FILE, --archetypes_sent_file ARCHETYPES_SENT_FILE
+                                Path to archetypes sentences file.
+        -dir SENTENCE_ENTROPY_DIR, --sentence_entropy_dir SENTENCE_ENTROPY_DIR
+                                Path to directory that has the sentence entropy files.
+        -te {any_risk_sw,annotations}, --test_group {any_risk_sw,annotations}
+                                This specifies if we're using the internal annotations or the task submission data data.
+        -df SENT_DF_PATH, --sent_df_path SENT_DF_PATH
+                                Path to sentence entropies file. This is an alternative to passing in --sentence_entropy_dir and --test_group.
+        -p PERCENTILE_THRESHOLD, --percentile_threshold PERCENTILE_THRESHOLD
+        -o SUBMISSION_FILE_PATH, --submission_file_path SUBMISSION_FILE_PATH
+        -ml MAX_OUTPUT_LEN, --max_output_len MAX_OUTPUT_LEN
+        --num_posts_to_show NUM_POSTS_TO_SHOW
+        --n_factors N_FACTORS
+        -w, --write
+    ```
+
+9. TODO: (optional) Make latex visual of highlighted spans
+    

--- a/relative-entropy/compare_systems.py
+++ b/relative-entropy/compare_systems.py
@@ -1,0 +1,148 @@
+""" code by Allie Lahnala, please reach of if you have questions or suggestions: alahnala@gmail.com """
+import argparse
+import json
+from tabulate import tabulate
+from collections import defaultdict
+import pandas as pd
+import os
+from config import DATADIR, MODELDIR
+
+
+
+def main(sys1_submission, sys2_submission, maxcolwidths=70):
+    s1_c2u = defaultdict(lambda:[])
+    s2_c2u= defaultdict(lambda:[])
+
+    for user_id, user_posts in user2posts.items():
+        risk_level = USER_TABLE.loc[int(user_id), 'label']
+
+        sys1_user_posts = sys1_submission[user_id]      
+        sys2_user_posts = sys2_submission[user_id]        
+
+        print(f"======= Evidence for user {user_id} | {risk_level} risk =======")
+        for post_id in user_posts:
+            sys1_highlights = sys1_user_posts[post_id]
+            sys2_highlights = sys2_user_posts[post_id]
+
+            # print("sys1:",  sys1_highlights)
+            # print("sys2:", sys2_highlights)
+
+            sys1_only = set(sys1_highlights) - set(sys2_highlights)
+            sys2_only = set(sys2_highlights) - set(sys1_highlights)
+
+            both = set(sys1_highlights).intersection(set(sys2_highlights))
+
+            print(f"* post_id: {post_id} | risk_level: {risk_level}")
+            
+            user_prediction_table = defaultdict(lambda:[])
+
+            sys1_highlights = list(sys1_only)
+            sys2_highlights = list(sys2_only)
+            print(f"\t* sys1 total: {len(sys1_highlights)} spans")
+            print(f"\t* sys2 total: {len(sys2_highlights)} spans")
+
+            max_len = max([len(sys1_highlights), len(sys2_highlights)])
+
+            for i in range(max_len):        
+                if i < len(sys1_highlights):
+                    user_prediction_table['a#'].append(i+1)
+                    user_prediction_table['sys1 only'].append(sys1_highlights[i])
+                else:
+                    user_prediction_table['a#'].append("")
+                    user_prediction_table['sys1 only'].append("")
+
+                if i < len(sys2_highlights):
+                    user_prediction_table['b#'].append(i+1)
+                    user_prediction_table['sys2 only'].append(sys2_highlights[i])
+                else:
+                    user_prediction_table['b#'].append("")
+                    user_prediction_table['sys2 only'].append("")
+            
+            if "a#" in user_prediction_table:
+                print(tabulate(pd.DataFrame(user_prediction_table).set_index('a#'), headers=user_prediction_table.keys(), maxcolwidths=maxcolwidths))
+                print("\n")
+        
+            if len(both) > 0:
+                both = {'Detected by both systems':list(both)}
+                print(tabulate(pd.DataFrame(both), headers=both.keys(), maxcolwidths=2*maxcolwidths))
+                print('\n')
+        
+        print("\n")
+        s1_c2u[sum([len(sys1_user_posts[p]) for p in user_posts])].append(user_id)
+        s2_c2u[sum([len(sys2_user_posts[p]) for p in user_posts])].append(user_id)
+        
+
+    if 0 in s1_c2u:
+        print("WARNING: System 1 has users with no spans! Users:", s1_c2u[0])
+    else:
+        print("System 1 has spans for all users.")
+    if 0 in s2_c2u:
+        print("WARNING: System 2 has users with no spans! Users:", s2_c2u[0])
+    else:
+        print("System 2 has spans for all users.")
+    
+
+
+def reformat_obj(spans_per_user):
+    d = {}
+    for user_id in spans_per_user:
+        d[user_id] = {}
+        for post_object in spans_per_user[user_id]['posts']:
+            d[user_id][post_object['post_id']] = post_object['highlights']
+    return d
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+                    prog="Compare systems",
+                    description="Compares the evidence spans extracted by each system")
+    parser.add_argument('-a', '--sys1', help="path to system 1's submission file", required=True)
+    parser.add_argument('-b', '--sys2', help="path to system 2's submission file", required=True)
+    parser.add_argument('--submission_file_path', default=os.path.join(MODELDIR, '_submission_files'))
+    parser.add_argument('-cw', '--maxcolwidth', help="determine the size of the highlight columns", default=70)
+    parser.add_argument('-u', '--user_table_path', help="path to user table", default=os.path.join(DATADIR, "clp24_user_table.csv"))
+    parser.add_argument('-te', '--test_group', choices=['any_risk_sw', 'annotations'], default='any_risk_sw', help="This specifies if we're using the internal annotations or the task submission data data.")
+
+    
+
+
+    ARGS = parser.parse_args()
+
+    if ARGS.test_group == 'annotations':
+        print('WARNING: Pipeline not fully tested on internal annotations.')
+        template_path = os.path.join(DATADIR, "annotations_template.json")
+    else:
+        template_path = os.path.join(DATADIR, "submission_template.json")
+    with open(template_path, 'r') as f:
+        TEMPLATE = json.load(f)
+    user2posts = reformat_obj(TEMPLATE)
+
+
+    """ check paths to system output files """
+    if not os.path.isfile(ARGS.sys1):
+        wo_json = ARGS.sys1.replace('.json', '')
+        ARGS.sys1 = os.path.join(ARGS.submission_file_path, f"{wo_json}.json")
+        if not os.path.isfile(ARGS.sys1):
+            print("ERROR: Can't find sys1 file.")
+            quit()
+    if not os.path.isfile(ARGS.sys2):
+        wo_json = ARGS.sys2.replace('.json', '')
+        ARGS.sys2 = os.path.join(ARGS.submission_file_path, f"{wo_json}.json")
+        if not os.path.isfile(ARGS.sys2):
+            print("ERROR: Can't find sys2 file.")
+            quit()
+
+    with open(ARGS.sys1, 'r') as f:
+        sys1_user_spans = json.load(f)
+    
+    with open(ARGS.sys2, 'r') as f:
+        sys2_user_spans = json.load(f)
+
+    sys1_user_spans = reformat_obj(sys1_user_spans)
+    sys2_user_spans = reformat_obj(sys2_user_spans)
+
+    USER_TABLE = pd.read_csv(ARGS.user_table_path, index_col=0)
+
+
+    main(sys1_user_spans, sys2_user_spans)

--- a/relative-entropy/compute_entropy.py
+++ b/relative-entropy/compute_entropy.py
@@ -1,0 +1,198 @@
+from config import DATADIR, MODELDIR
+""" code by Allie Lahnala, please reach of if you have questions or suggestions: alahnala@gmail.com """
+import argparse
+import pandas as pd
+from tqdm import tqdm
+from transformers import AutoTokenizer,AutoModelForCausalLM, AutoModelForMaskedLM
+import torch
+import os
+from glob import glob
+from collections import defaultdict
+import math
+import json
+
+
+def main():
+    """ Load data """
+    if ARGS.test_group == 'annotations':
+        # the annotated data comes from the training set so that's why we pass in the train path. 
+        # make sure that the LM was finetuned with the -x option to exclude the annotated posts.
+        data = get_data(ARGS.test_group, ARGS.all_labels_messages_train, annotations_path=ARGS.annotation_posts)
+    else:
+        data = get_data(ARGS.test_group, ARGS.all_labels_messages_test)
+
+    """ Load model """
+    tokenizer = AutoTokenizer.from_pretrained(ARGS.base_lm)
+    tokenizer.pad_token = tokenizer.eos_token    
+
+    """ tokenize data """
+    tokenized_data = []
+    lens = []
+    for message in tqdm(data.message, desc='Tokenizing data'):
+        tokenized = tokenizer(f"<|endoftext|> {message} <|endoftext|>")
+        tokenized_data.append(tokenized)
+        lens.append(len(tokenized.input_ids))
+
+    data['message_tokens'] = tokenized_data
+    data['message_lens'] = lens
+    del tokenized_data, lens
+
+
+    """ get losses """
+    if ARGS.lm_type == 'lm':
+        data['token_losses'] = causal_model_losses(data, ARGS.checkpoint_selection, ARGS.sw_size)
+    elif ARGS.lm_type == 'mlm':
+        data['token_losses'] = masked_model_losses(data, ARGS.checkpoint_selection)
+
+
+    """ save results """
+    token_loss_column = []
+    for _, row in tqdm(data.iterrows(), total=len(data)):
+        token_losses = {'id':[], 'token':[], 'loss':row['token_losses']}
+        token_ids = row['message_tokens'].input_ids
+        for t in token_ids:
+            token = tokenizer.decode(t)
+            token_losses['id'].append(t)
+            token_losses['token'].append(token)
+        token_loss_column.append(token_losses)
+
+    data[f"token_losses"] = token_loss_column
+    cols_to_save = ['post_id', 'user_id', f"token_losses"]
+    data[cols_to_save].to_json(OUTFILE)
+    print("saved losses to", OUTFILE)
+    return
+
+def get_data(group, all_messages_path, annotations_path=None):
+    all_messages = pd.read_csv(all_messages_path)
+
+    if group == 'annotations':
+        annotations = pd.read_csv(annotations_path)
+
+        data = all_messages[all_messages['post_id'].isin(annotations.message_id.unique())]
+        return data
+    else:
+        parts = group.split('_')
+        risk = parts[0][0].upper() + parts[0][1:]
+        if risk == 'Any':
+            data = all_messages[all_messages['label'] != 'No']
+        else:
+            data = all_messages[all_messages['label'] == risk]
+
+        if parts[-1] == 'all':
+            return data
+        elif parts[-1] == 'sw':
+            return data[data['subreddit'] == 'SuicideWatch']
+
+def masked_model_losses(data, model_checkpoint):
+    print("not implemented")
+    quit()
+
+
+
+def causal_model_losses(data, model_checkpoint,sw_size):
+    """TODO: change implementation to improve efficiency"""
+    model = AutoModelForCausalLM.from_pretrained(model_checkpoint).to(ARGS.device)
+
+    data_token_losses = [] # will have an entry per post
+    for _, row in tqdm(data.iterrows(), total=len(data), desc="Getting token losses from causal model"):
+        encodings = row['message_tokens']
+        seq_len = len(encodings.input_ids)
+
+        losses = [] # should have the loss for each token
+        for target_loc in range(0, seq_len):
+            beg_loc = max(target_loc-sw_size, 0)
+            input_ids = torch.tensor(encodings.input_ids[beg_loc:target_loc+1]).to(ARGS.device)
+            target_ids = input_ids.clone()
+            target_ids[:-1] = -100
+
+            with torch.no_grad():
+                outputs = model(input_ids, labels=target_ids)
+            loss = float(outputs.loss.detach().cpu())
+            losses.append(loss)
+        data_token_losses.append(losses)   
+
+    return data_token_losses   
+
+def get_checkpoint_states(model_dir, train_group): 
+    """
+    Returns:
+        - the path to the last trainer state (it includes all loss checkpoints)
+        - list of checkpoint step values
+    """
+    checkpoint_path = os.path.join(model_dir, train_group, "checkpoint-*", 'trainer_state.json') 
+    checkpoint_dirs = glob(checkpoint_path)
+    if len(checkpoint_dirs) == 0:
+        print(checkpoint_path)
+        print(f"No trainer state found for {train_group}")
+        return False
+    
+    checkpoint_step_values = [int(item.split('/')[-2].replace("checkpoint-", '')) for item in checkpoint_dirs]
+
+    last_checkpoint = max(checkpoint_step_values)    
+    trainer_state_path = checkpoint_path.replace("*", str(last_checkpoint))
+    return trainer_state_path, checkpoint_step_values
+
+def get_closest_to_min_eval_loss(df, checkpoint_steps, lms_path, lm):
+    min_step = df.sort_values(by='Eval loss').index[0]
+    dists = [abs(min_step-cv) for cv in checkpoint_steps]
+    idx = dists.index(min(dists))
+    closest_to_min_eval_step = checkpoint_steps[idx]
+    checkpoint_path = os.path.join(lms_path, lm, f"checkpoint-{closest_to_min_eval_step}")
+    return checkpoint_path
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+                    prog="python compute_entropy.py",
+                    description="Gets the token entropies for the test group data from the train group's finetuned language model.")
+    # input and output settings
+    parser.add_argument('-tr', '--train_group', choices=['low_risk_sw', 'high_risk_sw', 'moderate_risk_sw', 'low_risk_all', 'high_risk_all', 'moderate_risk_all', 'no_risk_sw', 'no_risk_all', 'any_risk_sw', 'any_risk_all'], required=True, help="This specifies the language model that we'll use to compute losses.")
+    parser.add_argument('-te', '--test_group', choices=['low_risk_sw', 'high_risk_sw', 'moderate_risk_sw', 'low_risk_all', 'high_risk_all', 'moderate_risk_all', 'no_risk_sw', 'no_risk_all', 'any_risk_sw', 'any_risk_all', 'annotations'], required=True, help="This specifies the data that the language model will be run on for losses.")    
+    parser.add_argument('-d', '--model_output_dir', type=str, help="Directory where the finetuned models are saved.", default=MODELDIR)
+    parser.add_argument('-o', '--token_entropies_dir', default=os.path.join(MODELDIR, '_token_entropies'), type=str, help="Directory path where you want to save the token entropies.")
+    parser.add_argument('--all_labels_messages_train', default=os.path.join(DATADIR, "all_labels_messages_train.csv"), type=str, help="Path to training data file.")
+    parser.add_argument('--all_labels_messages_test', default=os.path.join(DATADIR, "all_labels_messages_test.csv"), type=str, help="Path to test data file.")    
+    # modeling settings
+    parser.add_argument('-m', '--base_lm', choices=['distilgpt2', "lsanochkin/deberta-large-feedback", 'microsoft/deberta-base'], default='distilgpt2')
+    parser.add_argument('-lm', '--lm_type', choices=['lm', "mlm"], default="lm", help="lm: CausalLM | mlm: MaskedLM. Not implemented for mlm yet.")
+    parser.add_argument('--device', default="cuda", type=str)
+    parser.add_argument('-sw', '--sw_size', default=128, type=int, help="Context window size preceding target token.")
+    
+
+    parser.add_argument('--checkpoint_selection', help='Strategy for choosing the model checkpoint to load. Use a) min_eval_loss if you want to choose based on the minimum loss on the val set during training, b) last to use the last checkpoint, or c) a path to the checkpoint directory, e.g., model_dir/train_group/checkpoint-1000. ', default='min_eval_loss')
+
+
+    ARGS = parser.parse_args()
+
+    if ARGS.checkpoint_selection == 'min_eval_loss':
+        # get the checkpoint closest to the min eval loss step
+        trainer_state_file, checkpoint_steps = get_checkpoint_states(ARGS.model_output_dir, ARGS.train_group)
+
+        losses = defaultdict(lambda:{'Train loss':math.nan, 'Eval loss':math.nan, "epoch":math.nan})
+        with open(trainer_state_file, 'r') as f:
+            trainer_state = json.load(f)
+
+        for item in trainer_state['log_history']:
+            losses[item['step']]['epoch'] = item['epoch']
+            if 'eval_loss' in item:
+                losses[item['step']]['Eval loss'] = item['eval_loss']
+            if 'loss' in item:
+                losses[item['step']]['Train loss'] = item['loss']
+        df = pd.DataFrame(losses).T
+
+        ARGS.checkpoint_selection = get_closest_to_min_eval_loss(df, checkpoint_steps, ARGS.model_output_dir, ARGS.train_group)
+    elif ARGS.checkpoint_selection == 'last':
+        trainer_state_file, checkpoint_steps = get_checkpoint_states(ARGS.model_output_dir, ARGS.train_group)
+        ARGS.checkpoint_selection = trainer_state_file.replace('/trainer_state.json', '')
+
+    try:
+        assert os.path.isfile(os.path.join(ARGS.checkpoint_selection, 'model.safetensors'))
+    except:
+        print("Can't find model checkpoint from", ARGS.checkpoint_selection)
+        quit()
+    print("Using model checkpoint from:", ARGS.checkpoint_selection)
+    
+    OUTFILE = os.path.join(ARGS.token_entropies_dir, f"{ARGS.train_group}_on_{ARGS.test_group}.json")
+    os.makedirs(ARGS.token_entropies_dir, exist_ok=True)
+    print("Token entropies will be saved at:", OUTFILE)
+
+    main()

--- a/relative-entropy/finetune.py
+++ b/relative-entropy/finetune.py
@@ -1,0 +1,152 @@
+""" code by Allie Lahnala, please reach of if you have questions or suggestions: alahnala@gmail.com """
+from config import DATADIR, MODELDIR
+import warnings
+warnings.simplefilter("ignore", UserWarning)
+import argparse
+import pandas as pd
+from tqdm import tqdm
+from transformers import AutoTokenizer,AutoModelForCausalLM, TrainingArguments, Trainer,DataCollatorForLanguageModeling
+from transformers import AutoConfig
+import torch
+from collections import defaultdict
+import math
+import os
+
+def main():
+    """ Load data """
+    data = get_data(ARGS.train_group, ARGS.keep_annotations)
+
+    """ tokenize data """
+    tokenizer = AutoTokenizer.from_pretrained(ARGS.base_lm)
+    tokenizer.pad_token = tokenizer.eos_token
+    tokenized_data = []
+    for message in tqdm(data.message, total=len(data), desc='Tokenizing'):
+        tokenized = tokenizer(f"<|endoftext|> {message} <|endoftext|>", max_length=128, padding=True, truncation=True, stride=3, return_overflowing_tokens=True, return_special_tokens_mask=True, return_tensors="pt").to(ARGS.device)
+        tokenized_data.append(tokenized)
+    data['message_tokens'] = tokenized_data
+    del tokenized_data
+
+
+    """ Make Pytorch Dataset """
+    raw_dataset = defaultdict(lambda:[])
+    raw_dataset['index'] = []
+    for idx, row in data.iterrows():
+        tokens = row.message_tokens
+        for input_ids, attention_mask, overflow_to_sample_mapping in zip(tokens.input_ids, tokens.attention_mask, tokens.overflow_to_sample_mapping):
+            raw_dataset['index'].append(idx)
+            raw_dataset['message'].append(row.message)
+            raw_dataset['input_ids'].append(input_ids)
+            raw_dataset['attention_mask'].append(attention_mask)
+            raw_dataset['overflow_to_sample_mapping'].append(overflow_to_sample_mapping)
+
+    # in current implementation, data is shuffled when loaded.
+    train_len = int(ARGS.train_proportion*len(raw_dataset['input_ids']))
+    train_encodings = {'input_ids':raw_dataset['input_ids'][:train_len], 'attention_mask':raw_dataset['attention_mask'][:train_len]}
+    eval_encodings = {'input_ids':raw_dataset['input_ids'][train_len:], 'attention_mask':raw_dataset['attention_mask'][train_len:]}
+    train_dataset = Dataset(train_encodings)
+    eval_dataset = Dataset(eval_encodings)
+    print("Train data size:", len(train_dataset), "Eval data size:", len(eval_dataset))
+
+    data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+    """ Train model """
+    configuration = AutoConfig.from_pretrained(ARGS.base_lm)
+    configuration.hidden_dropout_prob = ARGS.hidden_dropout_prob
+    model = AutoModelForCausalLM.from_pretrained(ARGS.base_lm, config=configuration).to(ARGS.device)
+    training_args = TrainingArguments(
+        output_dir=checkpoint_dir,
+        evaluation_strategy=ARGS.eval_strategy,
+        learning_rate=ARGS.learning_rate,
+        weight_decay=ARGS.weight_decay,
+        num_train_epochs=ARGS.num_epochs,
+        save_strategy=ARGS.save_strategy,
+        logging_first_step=True,
+        logging_dir=ARGS.logging_dir,
+        logging_strategy='steps',
+        logging_steps=ARGS.logging_steps,
+    )
+    
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        data_collator=data_collator,
+    )
+
+    trainer.train()
+
+    eval_results = trainer.evaluate()
+    print(f"Perplexity: {math.exp(eval_results['eval_loss']):.2f}")
+    print("Checkpoints saved to", checkpoint_dir)
+
+def get_data(group, keep_annotations):
+    all_messages = pd.read_csv(ARGS.all_labels_messages_train).sample(frac=1)
+
+    if keep_annotations:
+        annotated_post_ids = ['29d4au', '1ulqbn', '1y8cw4', 'ml312', '3iu651', '1end6q',
+                                '34fj7p', '1811it', 'dtyiy', '3hmbre', '3i5n1a', '3j48ec',
+                                '1kmzqg', 'rsk6g', '2hurih', '2nr23j', '1yc6u7', '1zif0m',
+                                '2f9g97', '2nsqqm', '2swqdo', '3ghxts', '2dms1j', '2nzfj4',
+                                '1vzleb', '3g31xw', '2deltm', '1el5om', '1jpm72', '2i87k0',
+                                '2lsj9g', '2lxop0', '3hmw9z', '3iaxao', '27j41i', '37js2i',
+                                '1j7nhr', '3eaouc', '2r2hkk', '35wrom', '2vhag4', '276h4l',
+                                '3e1zc6', '2vxpos', '1wyqem', '1izo4t', '1d2gxo', '3ixiyn',
+                                '17j9yv', 'd82jc'] # post ids that we have annotated internally
+        all_messages = all_messages[~all_messages['post_id'].isin(annotated_post_ids)]
+
+    parts = group.split('_')
+    risk = parts[0][0].upper() + parts[0][1:]
+    if risk == 'Any':
+        data = all_messages[all_messages['label'] != 'No']
+    else:
+        data = all_messages[all_messages['label'] == risk]
+
+    if parts[-1] == 'all':
+        return data
+
+    elif parts[-1] == 'sw':
+        return data[data['subreddit'] == 'SuicideWatch']
+
+
+    
+class Dataset(torch.utils.data.Dataset):
+    def __init__(self, encodings):
+        self.encodings = encodings
+
+    def __getitem__(self, idx):
+        item = {key: torch.tensor(value[idx]) for key, value in self.encodings.items()}
+        return item
+
+    def __len__(self):
+        return len(self.encodings['input_ids'])
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+                    prog='finetune',
+                    description='Finetune a language model on a group of CLPsych users based on risk level.')
+    # input and output settings
+    parser.add_argument('-g', '--train_group', choices=['low_risk_sw', 'high_risk_sw', 'moderate_risk_sw', 'low_risk_all', 'high_risk_all', 'moderate_risk_all', 'no_risk_sw', 'no_risk_all', 'any_risk_sw', 'any_risk_all'], required=True)
+    parser.add_argument('-tr', '--all_labels_messages_train', default=os.path.join(DATADIR, "all_labels_messages_train.csv"), type=str, help="Path to training data file.")
+    parser.add_argument('-d', '--model_output_dir', type=str, help="Directory for saving the model checkpoints. They will be saved at [args.dir]/[args.train_group]. Recommended to make this unique to your experiment.", default=MODELDIR)
+    parser.add_argument('-k', '--keep_annotations', action='store_true', default=False, help='Pass in -k if you want to include the posts that we annotated internally.')
+    parser.add_argument('--logging_dir', default=None, type=str, help="Path to a logging dir if you don't want to use the default.")
+    # modeling params
+    parser.add_argument('--device', default="cuda", type=str)
+    parser.add_argument('-m', '--base_lm', choices=['distilgpt2'], help="Name of pre-trained language model you want to finetune.", default='distilgpt2')
+    parser.add_argument('-e', '--num_epochs', default=10, type=int)
+    parser.add_argument('-lr', '--learning_rate', default=2e-5, type=float)
+    parser.add_argument('-wd', '--weight_decay', default=.01, type=float)
+    parser.add_argument('-ss', '--save_strategy', default="epoch", type=str)
+    parser.add_argument('-es', '--eval_strategy', default="steps", type=str)
+    parser.add_argument('--logging_steps', default=50, type=int, help="Number of update steps between logs")
+    parser.add_argument('--hidden_dropout_prob', default=.1, type=float, help="Dropout")
+    parser.add_argument('--train_proportion', default=.9, type=float, help="Proportion of data to use for train, the rest will be used for eval.")
+    
+    ARGS = parser.parse_args()  
+
+    checkpoint_dir = os.path.join(ARGS.model_output_dir, ARGS.train_group)
+    print(f"Finetuned model checkpoints will be saved at {checkpoint_dir}")
+    os.makedirs(f'{checkpoint_dir}', exist_ok=True)
+
+    main()

--- a/relative-entropy/plot_loss.py
+++ b/relative-entropy/plot_loss.py
@@ -1,0 +1,110 @@
+""" code by Allie Lahnala, please reach of if you have questions or suggestions: alahnala@gmail.com """
+import os
+from glob import glob
+import json
+import pandas as pd
+import matplotlib.pyplot as plt
+import argparse
+import math
+import numpy as np
+from collections import defaultdict
+from config import MODELDIR
+
+def main():
+
+    print("Checkpoint of minimum eval loss:")
+    for lm in lms_to_plot:
+        trainer_state_file, checkpoint_steps = get_checkpoint_states(model_dir, lm)
+
+        if not trainer_state_file:
+            continue
+
+        losses = defaultdict(lambda:{'Train loss':math.nan, 'Eval loss':math.nan, "epoch":math.nan})
+        with open(trainer_state_file, 'r') as f:
+            trainer_state = json.load(f)
+
+        for item in trainer_state['log_history']:
+            losses[item['step']]['epoch'] = item['epoch']
+            if 'eval_loss' in item:
+                losses[item['step']]['Eval loss'] = item['eval_loss']
+            if 'loss' in item:
+                losses[item['step']]['Train loss'] = item['loss']
+        df = pd.DataFrame(losses).T
+
+        path_to_min_loss_checkpoint = get_closest_to_min_eval_loss(df, checkpoint_steps, model_dir, lm)
+
+
+        print(f"\t{lm}: step =", df.sort_values(by='Eval loss').index[0], " | epoch =", df.sort_values(by='Eval loss')['epoch'].values[0], " | path to closest checkpoint:", path_to_min_loss_checkpoint)
+
+        xs = np.array(df.index)
+        series1 = np.array(df['Eval loss'])
+        s1mask = np.isfinite(series1)
+
+        series2 = np.array(df['Train loss'])
+        s2mask = np.isfinite(series2)
+
+        plt.clf()
+        plt.plot(xs[s1mask], series1[s1mask], linestyle='-', marker='.', label='Eval loss')
+        plt.plot(xs[s2mask], series2[s2mask], linestyle='-', marker = '.', label='Train loss')
+        plt.legend(loc="lower left")
+        plt.title(f"{lm} loss")
+        plt.xlabel("Train step")
+        plt.ylabel("Loss")
+
+        save_path = os.path.join(plot_path, f"{lm}_eval.png")
+        plt.savefig(save_path)
+
+
+
+def get_checkpoint_states(lms_path, lm): 
+    """
+    Returns:
+        - the path to the last trainer state (it includes all loss checkpoints)
+        - list of checkpoint step values
+    """
+    checkpoint_path = os.path.join(lms_path, lm, "checkpoint-*", 'trainer_state.json') 
+    checkpoint_dirs = glob(checkpoint_path)
+    if len(checkpoint_dirs) == 0:
+        print(checkpoint_path)
+        print(f"No trainer state found for {lm}")
+        return False
+    
+    checkpoint_step_values = [int(item.split('/')[-2].replace("checkpoint-", '')) for item in checkpoint_dirs]
+
+    last_checkpoint = max(checkpoint_step_values)    
+    trainer_state_path = checkpoint_path.replace("*", str(last_checkpoint))
+    return trainer_state_path, checkpoint_step_values
+
+def get_closest_to_min_eval_loss(df, checkpoint_steps, lms_path, lm):
+    min_step = df.sort_values(by='Eval loss').index[0]
+    dists = [abs(min_step-cv) for cv in checkpoint_steps]
+    idx = dists.index(min(dists))
+    closest_to_min_eval_step = checkpoint_steps[idx]
+    checkpoint_path = os.path.join(lms_path, lm, f"checkpoint-{closest_to_min_eval_step}")
+    return checkpoint_path
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+                    prog="plot_loss.py",
+                    description="Plots train and eval losses for the language models you pass in.")
+    parser.add_argument('-lm', '--lm_to_plot', help="Name of the language models you want to plot. If passing in nothing, it will do all found LMs in --model_dir path.", nargs='+', default=['*'], required=False)
+    parser.add_argument('-d', '--model_dir', help="Directory where the lms are.", default=MODELDIR)
+    parser.add_argument('-o', '--plot_path', help="Directory where you want to save the plot images.", default=os.path.join(MODELDIR, '_loss_plots'))
+    
+
+    ARGS = parser.parse_args()
+
+    if ARGS.lm_to_plot[0] == '*':
+        """do all that are in ARGS.model_dir"""
+        trainer_state_paths = glob(os.path.join(ARGS.model_dir, '*', '*', 'trainer_state.json'))
+        lms_to_plot = list(set([p.split('/')[-3] for p in trainer_state_paths]))
+    else:
+        lms_to_plot = [lm.replace(',', '') for lm in ARGS.lm_to_plot]
+    
+
+    model_dir = ARGS.model_dir[:-1] if ARGS.model_dir[-1] == '/' else ARGS.model_dir
+    plot_path = ARGS.plot_path
+    os.makedirs(plot_path, exist_ok=True)
+
+    main()

--- a/relative-entropy/prepare_data.py
+++ b/relative-entropy/prepare_data.py
@@ -1,0 +1,55 @@
+""" 
+* This script prepares the data for the language modeling scripts. 
+* It will create two files:
+    1) [DATADIR]/all_labels_messages_train.csv
+    2) [DATADIR]/all_labels_messages_test.csv
+* Change where to save the files in the two lines after the imports, if you like.
+* Change the number of no risk posts to include in the test set, if you like. We go with a small sample.
+"""
+from config import DATADIR
+import warnings
+warnings.filterwarnings(action='ignore', category=UserWarning)
+import pandas as pd
+import os
+import random
+random.seed(20)
+
+# outfile paths
+train_outfile = os.path.join(DATADIR, "all_labels_messages_train.csv")
+test_outfile = os.path.join(DATADIR, "all_labels_messages_test.csv")
+
+# how many no risk posts from r/SuicideWatch and other subreddits you want to include in your test set
+no_risk_sw_test_size = 30 
+no_risk_other_test_size = 1000
+
+# Load the csv that contains all messages, including no risk.
+all_messages = pd.read_csv(os.path.join(DATADIR, "clp24_all_messages.csv"))
+
+# Load train and test post ids, and no risk post ids
+test_post_ids = pd.read_csv(os.path.join(DATADIR, "clp24_all_messages_test.csv")).post_id.values
+train_post_ids = pd.read_csv(os.path.join(DATADIR, "clp24_all_messages_train.csv")).post_id.values
+no_risk_sw_post_ids = list(all_messages[all_messages['label'] == 'No'][all_messages['subreddit'] == 'SuicideWatch'].post_id.values)
+no_risk_other_post_ids = list(all_messages[all_messages['label'] == 'No'][all_messages['subreddit'] != 'SuicideWatch'].post_id.values)
+all_no_risk_post_ids = no_risk_sw_post_ids + no_risk_other_post_ids
+
+# get a random sample of no risk posts for the train set
+no_risk_test_pids = random.sample(no_risk_sw_post_ids, k=no_risk_sw_test_size) + random.sample(no_risk_other_post_ids, k=no_risk_other_test_size)
+no_risk_train_pids = list(set(all_no_risk_post_ids) - set(no_risk_test_pids))
+
+# Put no risk user posts together with the users with risk data
+train_post_ids = list(train_post_ids) + list(no_risk_train_pids)
+test_post_ids = list(test_post_ids) + list(no_risk_test_pids)
+all_messages_train = all_messages[all_messages['post_id'].isin(train_post_ids)].sample(frac=1) # makes and shuffles the train data
+all_messages_test = all_messages[all_messages['post_id'].isin(test_post_ids)].sample(frac=1) # makes and shuffles the test data
+
+print('=== Train set posts per label ===\n', all_messages_train['label'].value_counts(), '\n')
+print('=== Test set posts per label  ===\n', all_messages_test['label'].value_counts())
+
+# save the data
+all_messages_train.to_csv(train_outfile, index=False)
+all_messages_test.to_csv(test_outfile, index=False)
+
+print("\nCreated files:")
+print(f"\t1) {train_outfile}")
+print(f"\t2) {test_outfile}")
+print('Data prep complete.')

--- a/relative-entropy/run_entropy_pipeline.sh
+++ b/relative-entropy/run_entropy_pipeline.sh
@@ -1,0 +1,41 @@
+
+
+# you need to have a config.py that has:
+#   DATADIR = # string pointing to the path of the clpsych24 shared task data, e.g., "/data/clp24/" 
+#   MODELDIR = # string pointing to a path to a directory where you want to save the finetuning output, e.g., "/data/clp24/finetune-output/"
+
+# 0. Prepare data (see readme, requires some initial steps and processing the official CLPsych data)
+python prepare_data.py
+
+# # 1. Finetune each model. Our shared task systems only used LMs finetuned on SuicideWatch posts.
+# python finetune.py --train_group no_risk_sw;
+# python finetune.py --train_group low_risk_sw;
+# python finetune.py --train_group moderate_risk_sw;
+# python finetune.py --train_group high_risk_sw;
+# python finetune.py --train_group any_risk_sw; 
+
+# 2. (optional) Plot losses.
+python plot_loss.py;
+
+# # 3. Compute entropies
+# #   a. compute token entropies from each group model on their own test data
+# python compute_entropy.py --train_group no_risk_sw --test_group no_risk_sw;
+# python compute_entropy.py --train_group any_risk_sw --test_group any_risk_sw;
+# python compute_entropy.py --train_group low_risk_sw --test_group low_risk_sw;
+# python compute_entropy.py --train_group moderate_risk_sw --test_group moderate_risk_sw;
+# python compute_entropy.py --train_group high_risk_sw --test_group high_risk_sw;
+# #   b. compute token entropies from each group model on any risk data
+# python compute_entropy.py --train_group no_risk_sw --test_group any_risk_sw;
+# python compute_entropy.py --train_group low_risk_sw --test_group any_risk_sw;
+# python compute_entropy.py --train_group moderate_risk_sw --test_group any_risk_sw;
+# python compute_entropy.py --train_group high_risk_sw --test_group any_risk_sw;
+
+
+# 4. make dataframe of sentence entropies
+python sentence_entropy.py
+
+# 5. span selection
+python span_selection.py -w # using -w will make the script write submission files with the span selection policies implemented in the script.
+
+# 6. (optional) compare two systems
+python compare_systems.py -a max_arch_score_70_submission -b prod_max_arc_ent_ac_70_submission

--- a/relative-entropy/run_entropy_pipeline.sh
+++ b/relative-entropy/run_entropy_pipeline.sh
@@ -7,28 +7,28 @@
 # 0. Prepare data (see readme, requires some initial steps and processing the official CLPsych data)
 python prepare_data.py
 
-# # 1. Finetune each model. Our shared task systems only used LMs finetuned on SuicideWatch posts.
-# python finetune.py --train_group no_risk_sw;
-# python finetune.py --train_group low_risk_sw;
-# python finetune.py --train_group moderate_risk_sw;
-# python finetune.py --train_group high_risk_sw;
-# python finetune.py --train_group any_risk_sw; 
+# 1. Finetune each model. Our shared task systems only used LMs finetuned on SuicideWatch posts.
+python finetune.py --train_group no_risk_sw;
+python finetune.py --train_group low_risk_sw;
+python finetune.py --train_group moderate_risk_sw;
+python finetune.py --train_group high_risk_sw;
+python finetune.py --train_group any_risk_sw; 
 
 # 2. (optional) Plot losses.
 python plot_loss.py;
 
-# # 3. Compute entropies
-# #   a. compute token entropies from each group model on their own test data
-# python compute_entropy.py --train_group no_risk_sw --test_group no_risk_sw;
-# python compute_entropy.py --train_group any_risk_sw --test_group any_risk_sw;
-# python compute_entropy.py --train_group low_risk_sw --test_group low_risk_sw;
-# python compute_entropy.py --train_group moderate_risk_sw --test_group moderate_risk_sw;
-# python compute_entropy.py --train_group high_risk_sw --test_group high_risk_sw;
-# #   b. compute token entropies from each group model on any risk data
-# python compute_entropy.py --train_group no_risk_sw --test_group any_risk_sw;
-# python compute_entropy.py --train_group low_risk_sw --test_group any_risk_sw;
-# python compute_entropy.py --train_group moderate_risk_sw --test_group any_risk_sw;
-# python compute_entropy.py --train_group high_risk_sw --test_group any_risk_sw;
+# 3. Compute entropies
+#   a. compute token entropies from each group model on their own test data
+python compute_entropy.py --train_group no_risk_sw --test_group no_risk_sw;
+python compute_entropy.py --train_group any_risk_sw --test_group any_risk_sw;
+python compute_entropy.py --train_group low_risk_sw --test_group low_risk_sw;
+python compute_entropy.py --train_group moderate_risk_sw --test_group moderate_risk_sw;
+python compute_entropy.py --train_group high_risk_sw --test_group high_risk_sw;
+#   b. compute token entropies from each group model on any risk data
+python compute_entropy.py --train_group no_risk_sw --test_group any_risk_sw;
+python compute_entropy.py --train_group low_risk_sw --test_group any_risk_sw;
+python compute_entropy.py --train_group moderate_risk_sw --test_group any_risk_sw;
+python compute_entropy.py --train_group high_risk_sw --test_group any_risk_sw;
 
 
 # 4. make dataframe of sentence entropies

--- a/relative-entropy/sentence_entropy.py
+++ b/relative-entropy/sentence_entropy.py
@@ -1,0 +1,321 @@
+import warnings
+warnings.filterwarnings(action='ignore', category=RuntimeWarning)
+import argparse
+import pandas as pd
+from tqdm import tqdm
+from collections import defaultdict
+import os
+import numpy as np
+import json
+from glob import glob
+import difflib
+from config import DATADIR, MODELDIR
+
+
+def main():
+
+    post_df = pd.read_csv(ARGS.all_messages)   
+    post_df = post_df[post_df['post_id'].isin(POST_IDS)].set_index('post_id')  
+    sentences_df = pd.read_csv(ARGS.sent_tokenized_file)
+    sentences_df = sentences_df[sentences_df['post_id'].isin(POST_IDS)]  
+
+    """get token entropy file paths """
+    entropy_files = glob(os.path.join(ARGS.token_entropies_dir, '*.json'))
+    relevant_entropy_files = []
+    for fi in entropy_files:
+        test_group = fi.replace('.json', '').split('_on_')[-1].replace("_all", "").replace("_sw", "")
+        if "no_risk" not in test_group:
+            relevant_entropy_files.append(fi)
+
+    token_entropies_df = load_token_entropies(relevant_entropy_files, post_df)
+
+    """ Compute token-level entropy differences """
+    post_ents_and_ent_diffs = compute_entropy_differences(token_entropies_df, post_df)
+    
+    """ INDEX TEST DATA TOKENS INTO MESSAGE STRING POSITIONS -- this had to involve some manual tricks because of encoding differences """
+    post_token_index_df = index_post_tokens(post_ents_and_ent_diffs)
+    
+
+    """ INDEX SENTENCE DATA TOKENS INTO MESSAGE STRING POSITIONS """
+    sentence_token_index_df = index_sentence_tokens(sentences_df)
+    post_token_index_df = pd.concat([post_token_index_df, sentence_token_index_df], axis=1)
+
+
+    """ check on matches """
+    matching = post_token_index_df.message_strip_du == post_token_index_df.message_strip_t
+    verify_maps(post_token_index_df, matching)    
+
+
+    """ add ent diffs to post_token_index_df """
+    post_token_index_df = pd.concat([post_token_index_df, post_ents_and_ent_diffs], axis = 1)#.columns
+
+
+    """ Map and aggregate """
+    sentence_tokens_df = map_tokens_to_sentences(post_token_index_df, post_ents_and_ent_diffs, sentences_df)
+    df, diff_aggregations = aggregate(sentence_tokens_df)
+
+    outfile = os.path.join(ARGS.outdir, f'{ARGS.test_group}_sentence_entropies.json')
+    print(f'SAVING {outfile}')    
+    df.to_json(outfile)
+    
+
+    print("\nPrinting top 5 sents by agg differences")
+    for col in diff_aggregations.columns:
+
+        matching = df.sort_values(by=col, ascending=False)#[['sentence', 'label']]
+        print(f"== {col} ==")
+        for sent in matching.sentence.values[:5]:
+            print(f"\t{sent}")
+
+    print("\nSentence entropies file is saved at:", outfile)
+    return
+
+    
+def load_token_entropies(entropy_files, post_df):
+    """ load token losses """
+    post_id2entropy_lists = defaultdict(lambda:{})
+    all_keys = defaultdict(lambda:0)
+
+    for fi in tqdm(sorted(entropy_files, reverse=True)):
+        fi_name = fi.split('/')[-1]
+        train_group = fi_name.replace('.json', '').split('_on_')[0]
+        all_keys[train_group] += 1
+
+        df = pd.read_json(fi)
+        df = df[df['post_id'].isin(POST_IDS)]
+
+        for _, row in df.iterrows():
+            post_id2entropy_lists[row.post_id][train_group] = row.token_losses
+
+    entropy_columns = defaultdict(lambda:[])
+    sg = list(all_keys.keys())[0]
+    for post_id, row in tqdm(post_df.iterrows(), total=len(post_df), desc="Getting token entropy columns for each post"):
+        token_ids = post_id2entropy_lists[post_id][sg]['id'][1:]
+        tokens = post_id2entropy_lists[post_id][sg]['token'][1:]
+        entropy_columns['post_id'].append(post_id)
+        entropy_columns['token_ids'].append(token_ids)
+        entropy_columns['tokens'].append(tokens)
+
+
+        entropy_dict = post_id2entropy_lists[post_id]
+        for m in all_keys:
+            if m in entropy_dict:
+                entropy_columns[m].append(np.array(entropy_dict[m]['loss'][1:]))
+            else:
+                entropy_columns[m].append(None)
+
+    entropy_columns = pd.DataFrame(entropy_columns).set_index('post_id')
+    return entropy_columns
+
+
+def compute_entropy_differences(token_entropies_df, post_df):
+    difference_columns = defaultdict(lambda:[])
+
+    risk_columns = [col for col in token_entropies_df.columns if 'no_risk' not in col and ('risk' in col or 'annotations' in col)]
+    minuends = [c for c in ['no_risk_all', 'no_risk_sw'] if c in token_entropies_df.columns]
+    
+    for post_id, row in token_entropies_df.iterrows():   
+        difference_columns['post_id'].append(post_id)
+        tr_diffs = {}
+
+        for col in risk_columns:
+            for c in minuends:
+                    
+                if type(row[col]) == np.ndarray:
+                    tr_diffs[c] = row[c] - row[col]                    
+                else:
+                    tr_diffs[c] = None
+
+            colname = ''.join([i[0].upper() + i[1:] for i in col.split('_risk_')])
+            for c in minuends:
+                cname = ''.join([i[0].upper() + i[1:] for i in c.split('_risk_')])
+                difference_columns[f"{cname}-{colname}"].append(tr_diffs[c])
+
+    difference_columns = pd.DataFrame(difference_columns).set_index('post_id')
+
+    post_ents_and_ent_diffs = pd.concat([post_df, token_entropies_df, difference_columns], axis=1)
+    if ARGS.save_intermediate_values:
+        outfile = os.path.join(ARGS.outdir, 'post_ents_and_ent_diffs.json')
+        print(f'SAVING {outfile}')    
+        post_ents_and_ent_diffs.to_json(outfile)
+
+
+    return post_ents_and_ent_diffs
+    
+def index_post_tokens(post_ents_and_ent_diffs):
+    test_on_test = defaultdict(lambda:[])
+    sample2message_token_idx = []
+    tdata_message = []
+    for post_id, row in tqdm(post_ents_and_ent_diffs.iterrows(), total=len(post_ents_and_ent_diffs), desc="Mapping token idx to message idx"):
+        test_on_test['post_id'].append(post_id)
+
+        tokens = row.tokens
+        # while '\"' in tokens:
+        #     tokens.remove('\"')
+
+        message = ""
+        tidx2midx = {}
+        for tidx, token in enumerate(tokens):
+            # tidx = i + 1 # because skipping the bos token
+            token = token.strip().replace('<|endoftext|>', '')#.replace("����", "😊😓")#.replace("\ufffd", "’") # hacky thing to deal with ' having resulted in \ufffd after tokenizing/writing to file
+            tstart = len(message)
+            message += token
+            tend = len(message)
+            tidx2midx[tidx] = (tstart, tend)
+
+        sample2message_token_idx.append(tidx2midx)
+        message = message.replace("\"", "")
+        tdata_message.append(message)  
+
+    test_on_test['tidx2midx'] = sample2message_token_idx
+    test_on_test['message_strip_t'] = tdata_message
+    test_on_test = pd.DataFrame(test_on_test).set_index('post_id')
+    return test_on_test
+
+def index_sentence_tokens(sentences_df):
+    sample2message_token_idx = []
+    tdata_message = []
+    post_ids = []
+    for post_id, frame in tqdm(sentences_df.groupby('post_id'), total=sentences_df.post_id.nunique(), desc="Mapping sentence tokens"):
+        msg = ""
+        duidx2midx = {}
+        for _, row in frame.iterrows():
+            # if math.isnan(row['message']):
+            if type(row['sentence']) != str:
+                print(row['sentence'])
+                continue
+                
+            duid = row['message_id']
+            du_msg = ''.join(row['sentence'].split())#.replace('’', '’’') # hacky thing to deal with ' having resulted in \ufffd after tokenizing/writing to file 
+            dustart = len(msg)
+            msg += du_msg
+            duend = len(msg)
+            duidx2midx[duid] = (dustart, duend)
+        sample2message_token_idx.append(duidx2midx)
+        # msg = msg.replace('&', '&amp;')
+        msg = msg.replace('<', '&lt;')
+        msg = msg.replace('’', '��')
+        msg = msg.replace('“', '��')
+        msg = msg.replace('”', '��')
+        msg = msg.replace("\"", "")
+        msg = msg.replace('\\t', '')
+        msg = msg.replace("😊😓", '����')
+        if msg[-3:] == 'nan':
+            msg = msg[:-3]
+        tdata_message.append(msg)
+        post_ids.append(post_id)
+    post_dunits = pd.DataFrame({'post_id':post_ids, 'duidx2midx':sample2message_token_idx, 'message_strip_du':tdata_message}).set_index('post_id')
+    
+    return post_dunits
+
+
+def verify_maps(post_token_index_df, matching):
+    print("If there are issues with matching the strings, the differences will print below, and there might be issues later...")
+    cases = post_token_index_df[~matching][['message_strip_t', 'message_strip_du']].values
+    for a,b in cases:     
+        print('{}\n{}'.format(a,b))  
+        for i,s in enumerate(difflib.ndiff(a, b)):
+            if s[0]==' ': continue
+            elif s[0]=='-':
+                print(u'\tDelete "{}" from position {}'.format(s[-1],i))
+            elif s[0]=='+':
+                print(u'\tAdd "{}" to position {}'.format(s[-1],i))    
+        print()  
+    print("String difference checks complete.")
+
+def map_tokens_to_sentences(post_token_index_df, post_ents_and_ent_diffs, sentences_df):
+    sentence_tokens_df = defaultdict(lambda:[])
+    ent_columns = post_ents_and_ent_diffs.columns[10:]
+
+
+    for post_id, row in tqdm(post_token_index_df.iterrows(), total = len(post_token_index_df)):
+        duidx2midx = row['duidx2midx']
+        tidx2midx = row['tidx2midx']
+
+        for duid, (dustart, duend) in duidx2midx.items():
+            entropy_token_idx = []
+            for tidx, (tstart, tend) in tidx2midx.items():
+                # does tend actually matter? probably not when the messages are equal
+                if tstart >= dustart and tstart < duend and tidx < len(row['tokens']):
+                    entropy_token_idx.append(tidx)
+                
+
+            du_message = sentences_df[sentences_df['message_id'] == duid]['sentence'].values[0]
+            du_tokens = [row['tokens'][tidx] for tidx in entropy_token_idx]
+            du_token_ids = [row['token_ids'][tidx] for tidx in entropy_token_idx]
+
+            sentence_tokens_df['message_id'].append(duid)
+            sentence_tokens_df['post_id'].append(post_id)
+            sentence_tokens_df['label'].append(row.label)
+            sentence_tokens_df['sentence'].append(du_message)
+            sentence_tokens_df['tokens'].append(du_tokens)
+            sentence_tokens_df['token_ids'].append(du_token_ids)
+            sentence_tokens_df['entropy_token_idx'].append(entropy_token_idx)
+
+            for col in ent_columns:
+                ent_list = post_ents_and_ent_diffs.loc[post_id, col]
+                sentence_entropies = [ent_list[tidx] for tidx in entropy_token_idx]
+                sentence_tokens_df[col].append(sentence_entropies)
+
+    sentence_tokens_df = pd.DataFrame(sentence_tokens_df).set_index('message_id')
+    if ARGS.save_intermediate_values:
+        outfile = os.path.join(ARGS.outdir, f'{ARGS.test_group}_tokens_to_sentences.json')
+        print(f'SAVING {outfile}')    
+        sentence_tokens_df.to_json(outfile)
+    return sentence_tokens_df
+
+
+def aggregate(sentence_tokens_df):
+    diff_columns = [col for col in sentence_tokens_df.columns if "-" in col]
+    diff_aggregations = defaultdict(lambda:[])
+
+    # get max, median, mean of all the differences
+    for message_id, row in sentence_tokens_df.iterrows():
+        diff_aggregations[f'message_id'].append(message_id)
+
+        for col in diff_columns:
+            diff_aggregations[f'{col}_mean'].append(np.mean(row[col]))
+            diff_aggregations[f'{col}_median'].append(np.median(row[col]))
+            diff_aggregations[f'{col}_max'].append(max(row[col]) if len(row[col]) > 0 else 0)
+
+    diff_aggregations = pd.DataFrame(diff_aggregations).set_index('message_id')
+    df = pd.concat([sentence_tokens_df, diff_aggregations], axis=1)
+    return df, diff_aggregations
+    
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+                    prog="python sentence_entropy.py",
+                    description="Aggregates the token entropies at sentence level. Output file by default is {ARGS.test_group}_sentence_entropies.json")
+    parser.add_argument('-dir', '--token_entropies_dir', default=os.path.join(MODELDIR, '_token_entropies'), type=str, help="Directory where you have the token entropies saved.")
+
+    
+    parser.add_argument('-o', '--outdir', type=str, help="Directory where you want to save the sentence entropies.", default=os.path.join(MODELDIR, '_sentence_entropies'))
+    parser.add_argument('--all_messages', default=os.path.join(DATADIR, "clp24_all_messages.csv"), type=str, help="Path to test data file.")    
+    parser.add_argument('-st', '--sent_tokenized_file', default=os.path.join(DATADIR, "clp24_SW_messages_sent_tokenized.csv"), type=str, help="Path to the data broken into sentences.")
+    parser.add_argument('-te', '--test_group', choices=['any_risk_sw', 'annotations'], default='any_risk_sw', help="This specifies if we're using the internal annotations or the task submission data data.")
+    parser.add_argument('-s', '--save_intermediate_values', action='store_true', help="Pass in if you want intermediate values to be written to a file.")
+
+
+
+    ARGS = parser.parse_args()
+
+    if ARGS.test_group == 'annotations':
+        print("Pipeline not fully tested for internal annotations set yet.")
+        POST_IDS = ['29d4au', '1ulqbn', '1y8cw4', 'ml312', '3iu651', '1end6q',
+                    '34fj7p', '1811it', 'dtyiy', '3hmbre', '3i5n1a', '3j48ec',
+                    '1kmzqg', 'rsk6g', '2hurih', '2nr23j', '1yc6u7', '1zif0m',
+                    '2f9g97', '2nsqqm', '2swqdo', '3ghxts', '2dms1j', '2nzfj4',
+                    '1vzleb', '3g31xw', '2deltm', '1el5om', '1jpm72', '2i87k0',
+                    '2lsj9g', '2lxop0', '3hmw9z', '3iaxao', '27j41i', '37js2i',
+                    '1j7nhr', '3eaouc', '2r2hkk', '35wrom', '2vhag4', '276h4l',
+                    '3e1zc6', '2vxpos', '1wyqem', '1izo4t', '1d2gxo', '3ixiyn',
+                    '17j9yv', 'd82jc'] # post ids that we have annotated internally
+    elif ARGS.test_group == 'any_risk_sw':
+        POST_IDS = ['2v6c9q', '3e8si7', '2j44ow', '2xe7hp', '3bhds2', '3d2ttx', '1kpxiu', '1d7nab', '1unus3', '3h9o7o', '3hh29z', 'vkxfb', '2nledl', '2dv5mw', '3ejsiv', '2il6xf', '3iagg6', '3h0z05', '2ff664', '32i9nz', '2a7wms', 'g7f7g', '280apu', '20kbpj', '2xa7jl', '17r00i', '3fuxue', '3c83gc', '3gcaik', '1azxoz', '39akaq', '22l8w4', '2mb3ku', '2h4b4q', '2xrnry', '2m9gm4', '2sq2me', '3ic4t8', '2vcol2', '32b7zk', '33kh5m', '35ylua', 'yaqxi', '2b3y50', '2booi6', '16d5de', '3fvr4l', '1shwnv', '31dz04', 'l5jxp', '3dv1gk', '2rp5bb', '319ioh', '2uquru', '1631gw', '30xti7', '32jo2k', '1tplbc', 'k76ov', '21mm33', '241gpm', '2v0w14', 'xfyos', '2f7wj4', '1ftvgt', '2j2t7i', '2zqq2c', '32o53l', '1wj80m', '3gizbj', '3gx2sj', '36eh73', '3am642', '2e5zho', '1w6g6u', '3hy1hk', '3i9p8b', '16xkll', '1ph5yt', '1gceob', '1t7se3', '3dthkh', '1y298o', '2jo2q0', '23tvqs', '2zienb', '2aqb2a', '2kvmof', 'mxci8', '13c9hl', '1455fd', '2u5z30', '36xc3s', '383n1f', '3cq8kt', '38bc2o', '26nqsc', '1getay', '1gwlbb', '2evvoo', '2uafbk', '2c7y41', '3gjkm6', '2iz5y7', '2h1vke', '35miyb', '2y7a6g', '3ci2ni', '2f27hy', '33r8b6', '1otrx6', '2802g5', '2z2q1f', '35lq71', '12umtk', '24u2gv', '1mjszi', '2d3de4', '3152g6', '3f9nd4', '3gk55c', '1pl51l', '2qlffz', '30reha', '1xpagm', '2017wz', '357o7f', '2scmvs', '2u91iq', '1zhg6p', '224i1n', '227n97', '2fwbqi', '25rnwu', '2x08xn', '3hxe6j', '2jfo9n', '2onplv', '278mzu', '1k3agb', '2yek5b', '2ng6fr', '1wb4qr', '2wsqbn', '2nmehc', '20d48v', '10llu1', '3896jf', '37jcax', '2dq4gx', '2tfdb4', '3ff64x', 'pnkh4', '15j1ft', '19jxq1', 'thn6n', 'ev6tp', '2gt6wk', '2hnma9', '3akx6o', '3f7iqw', '189w0w']
+    
+    os.makedirs(ARGS.outdir, exist_ok=True)
+
+    main()

--- a/relative-entropy/span_selection.py
+++ b/relative-entropy/span_selection.py
@@ -1,0 +1,339 @@
+""" code by Vasudha Varadarajan and Allie Lahnala, please reach of if you have questions or suggestions: alahnala@gmail.com """
+import warnings
+warnings.filterwarnings(action='ignore', category=RuntimeWarning)
+import argparse
+import pandas as pd
+import os
+import numpy as np
+import json
+from tabulate import tabulate
+from factor_analyzer import FactorAnalyzer
+from factor_analyzer.factor_analyzer import calculate_bartlett_sphericity, calculate_kmo
+from copy import deepcopy
+from config import MODELDIR, DATADIR
+
+
+def main():
+
+    sent_df = pd.read_json(ARGS.sent_df_path)
+    archetypes_sent = pd.read_csv(ARGS.archetypes_sent_file)
+    archetypes_sent = archetypes_sent[archetypes_sent['message_id'].isin(sent_df.post_id.unique())]
+    try:
+        assert archetypes_sent.message_id.nunique() == sent_df.post_id.nunique()
+    except:
+        print("Sentence archetypes file is missing posts.")
+        quit()
+
+    
+    """ 
+    ===== map ids to join dataframes =====
+    """
+    archidx2sentidx = {}
+    for post_id, frame in sent_df.groupby(by='post_id'):
+        arch_frame = archetypes_sent[archetypes_sent['message_id'] == post_id]
+        assert all(arch_frame.text.values == frame.sentence.values)
+        for k,v in zip(arch_frame.index.values, frame.index.values):
+            archidx2sentidx[k] = v
+
+    archetypes_id_column = []
+    for idx, _ in archetypes_sent.iterrows():
+        new_id = archidx2sentidx[idx]
+        archetypes_id_column.append(new_id)
+
+    archetypes_sent['sent_id'] = archetypes_id_column
+    archetypes_sent = archetypes_sent.set_index('sent_id')
+    df = pd.concat([sent_df, archetypes_sent], axis=1)
+
+
+    """ 
+    ===== compute max archetype scores =====
+    """
+    df["max_arch_score"] = df.apply(lambda x: max([x[i] for i in archetypes]), axis=1)
+    df["mean_arch_score"] = df.apply(lambda x: sum([x[i] for i in archetypes])/len(archetypes), axis=1)
+    df["numeric_label"] = df["label"].apply(lambda x: {"Low": 1, "Moderate": 2, "High": 3}[x])
+
+    # print_head(df, columns=['post_id', 'user_id', 'label', 'sentence', 'max_arch_score', 'mean_arch_score']) 
+
+    """ 
+    ===== Factor Analysis =====
+    """
+
+    print("====== Factor analysis on all archetypes ======")
+    chi_square_value,p_value=calculate_bartlett_sphericity(df[archetypes])
+    kmo_all,kmo_model=calculate_kmo(df[archetypes])
+
+    print(f"\t* bartlett_sphericity(all archetypes)={chi_square_value}| pval={p_value}")
+    print(f"\t* kmo(all archetypes)={kmo_model}")
+
+    print("\n\t* factor analysis eigenvalues (all archetypes)")
+    # Create factor analysis object and perform factor analysis
+    fa = FactorAnalyzer(rotation=None)
+    fa.fit(df[archetypes])
+    # Check Eigenvalues
+    ev, v = fa.get_eigenvalues()
+    for i in ev:
+        print(f"\t\t{i}")
+
+    print("\n====== Factor analysis on three joiner archetypes ======")
+    print(f"\t* Archetypes:")
+    for a in joiner_three_archs:
+        print(f"\t\t* {a}")
+    print_head(df, columns=joiner_three_archs) 
+
+    fa = FactorAnalyzer(rotation=None)
+    fa.fit(df[joiner_three_archs])
+    # Check Eigenvalues
+    print(f"\n\t* factor analysis eigenvalues ({joiner_three_archs})")
+    ev, v = fa.get_eigenvalues()
+    for i in ev:
+        print(f"\t\t{i}")
+
+    # fit a single factor
+    j3_n_factors = 1
+    fa = FactorAnalyzer(n_factors=j3_n_factors, rotation="varimax")
+    fa.fit(df[joiner_three_archs])
+
+    # shifting factor factor to use in products
+    df["joiner3_arcs_factor"] =  fa.transform(df[joiner_three_archs]).mean(axis=1)
+    if j3_n_factors == 1:
+        df["joiner3_arcs_factor"] = df["joiner3_arcs_factor"] * -1
+    df["joiner3_arcs_factor_shifted"] = abs(df["joiner3_arcs_factor"].min()) + df["joiner3_arcs_factor"]
+    smooth = df["joiner3_arcs_factor_shifted"].sort_values().values[1] / 2
+    df["joiner3_arcs_factor_shifted"] = smooth + df["joiner3_arcs_factor_shifted"]
+
+    print(f"\n\t* top {ARGS.num_posts_to_show} posts with highest joiner3 factor")
+    for i in df.sort_values(by="joiner3_arcs_factor", ascending=False).head(ARGS.num_posts_to_show).index:
+        print(f"\t\t* {df.loc[i].sentence[:ARGS.max_output_len]}")
+
+    print(f"\n\t* bottom {ARGS.num_posts_to_show} posts with lowest joiner3 factor")
+    for i in df.sort_values(by="joiner3_arcs_factor", ascending=True).head(ARGS.num_posts_to_show).index:
+        print(f"\t\t* {df.loc[i].sentence[:ARGS.max_output_len]}")
+
+
+
+    print("\n====== Factor analysis on entropies ======")
+    relevant_entropies = sorted([
+        "NoSw-LowSw_max",
+        "NoSw-HighSw_max",
+        "NoSw-ModerateSw_max",
+        "NoSw-AnySw_max"
+    ])
+
+    #rank of eigen matrix
+    # Create factor analysis object and perform factor analysis
+    fa = FactorAnalyzer(rotation=None)
+    fa.fit(df[relevant_entropies])
+    # Check Eigenvalues
+    print(f"\n\t* factor analysis eigenvalues ({relevant_entropies})")
+    ev, v = fa.get_eigenvalues()
+    for i in ev:
+        print(f"\t\t{i}")
+
+    # fit a single factor
+    # fa = FactorAnalyzer(n_factors=1, rotation="varimax")
+    ent_n_factors = 1
+    fa = FactorAnalyzer(n_factors=ent_n_factors) # used 2 as last min choice because of issue with vals flipping
+    fa.fit(df[relevant_entropies])
+    #flatten the array
+    df["entropy_factor"] =  fa.transform(df[relevant_entropies]).mean(axis=1)
+    if ent_n_factors == 1:
+        df["entropy_factor"] = df["entropy_factor"] * -1
+    #print top 30 posts with highest entropy factor
+    print(f"\n\t* top {ARGS.num_posts_to_show} posts with highest entropy factor")
+    for i in df.sort_values(by="entropy_factor", ascending=False).head(ARGS.num_posts_to_show).index:
+        print(f"\t\t* {df.loc[i].sentence[:ARGS.max_output_len]}")
+
+    print(f"\n\t* bottom {ARGS.num_posts_to_show} posts with lowest entropy factor")
+    for i in df.sort_values(by="entropy_factor", ascending=True).head(ARGS.num_posts_to_show).index:
+        print(f"\t\t* {df.loc[i].sentence[:ARGS.max_output_len]}")
+
+
+    # shifting entropy factor to use in products
+    df["entropy_factor_shifted"] = abs(df["entropy_factor"].min()) + df["entropy_factor"]
+    smooth = df["entropy_factor_shifted"].sort_values().values[1] / 2
+    df["entropy_factor_shifted"] = smooth + df["entropy_factor_shifted"]
+
+
+
+
+    """
+
+    === Compute Policy Scores ===
+
+    """
+
+    # for products, use shifted values so there are no negatives
+    df['prod_AC_ent'] = df['Acquired Capability - Ideation/Simulation'] * df['entropy_factor_shifted']
+    df['prod_max_arc_ent'] = df['max_arch_score'] * df['entropy_factor_shifted']
+    df['prod_j3_ent'] = df['joiner3_arcs_factor_shifted'] * df['entropy_factor_shifted']
+    df['prod_j3_ent_ac'] = df['prod_j3_ent'] + df['Acquired Capability - Ideation/Simulation']
+    df['prod_max_arc_ent_ac'] = df['prod_max_arc_ent'] + df['Acquired Capability - Ideation/Simulation']
+
+    # for sums it doesn't matter if you use the shifted/original
+    df['sum_AC_ent'] = df['Acquired Capability - Ideation/Simulation'] + df['entropy_factor']
+    df['sum_max_arc_ent'] = df['max_arch_score'] + df['entropy_factor']
+    df['sum_j3_ent'] = df['joiner3_arcs_factor'] + df['entropy_factor']
+
+
+    """
+    
+    === Preview scores at threshold ===
+    
+    """
+    df['sentence'] = df['sentence'].apply(lambda x: x.strip())
+    print(df)
+    print("\n====== Preview policy scores at threshold  ======")
+    # for score in ['prod_AC_ent', 'prod_max_arc_ent', 'prod_j3_ent', 'sum_AC_ent', 'sum_max_arc_ent', 'sum_j3_ent']:
+    # for score in ['prod_j3_ent+ac', 'prod_max_arc_ent+ac']:
+    # for score in ['sum_max_arc_ent', 'prod_max_arc_ent', 'prod_AC_ent', 'prod_j3_ent+ac', 'prod_j3_ent']:
+    for score in ['sum_max_arc_ent', 'prod_max_arc_ent', 'prod_AC_ent', 'prod_j3_ent_ac', 'prod_j3_ent', 'entropy_factor_shifted', 'max_arch_score', 'prod_max_arc_ent_ac']:
+    # for score in ['entropy_factor_shifted']:
+    # for score in ['max_arch_score', 'joiner3_arcs_factor', 'Acquired Capability - Ideation/Simulation']:
+    # for score in ['prod_max_arc_ent', 'prod_j3_ent', 'prod_AC_ent', 'joiner3_arcs_factor']:
+        print(f"\n* {score}")
+
+        top_percentile = df[df[score] >= np.percentile(df[score], ARGS.percentile_threshold)]
+        print("\t* Highest scoring sentences")
+        ct = 1
+        for i in top_percentile.sort_values(by=score, ascending=False).index[:ARGS.num_posts_to_show]:
+            print(f"\t\t{ct}. {df.loc[i].sentence[:ARGS.max_output_len]}")
+            ct+=1
+        
+        ct = 1
+        print("\t* Lowest scoring sentences above threshold")
+        for i in top_percentile.sort_values(by=score, ascending=True).index[:ARGS.num_posts_to_show]:
+            print(f"\t\t{ct}. {df.loc[i].sentence[:ARGS.max_output_len]}")
+            ct+=1
+
+        ct = 1
+        bottom_percentile = df[df[score] < np.percentile(df[score], ARGS.percentile_threshold)]
+        print("\t* Highest scoring sentences below threshold (won't be highlighted)")
+        for i in bottom_percentile.sort_values(by=score, ascending=False).index[:ARGS.num_posts_to_show]:
+            print(f"\t\t{ct}. {df.loc[i].sentence[:ARGS.max_output_len]}")
+            ct+=1
+
+        
+        
+
+    """ Option to save dataframe with all these values """
+    if ARGS.save_df:
+        df.to_json(ARGS.save_df)    
+
+    """
+    
+    === Write Submission Files ===
+    
+    """
+    if ARGS.write:
+        print("\n====== Writing submission files...  ======")
+        for score in ['sum_max_arc_ent', 'prod_max_arc_ent', 'prod_AC_ent', 'prod_j3_ent_ac', 'prod_j3_ent', 'entropy_factor_shifted', 'max_arch_score', 'prod_max_arc_ent_ac']:
+
+            top_percentile = df[df[score] >= np.percentile(df[score], ARGS.percentile_threshold)]
+            write_submission(top_percentile, score, ARGS.percentile_threshold, df)
+    
+    return
+
+
+def print_head(df, columns=None, rows=5, maxcolwidths=20, showindex=False):
+    columns = columns if columns else list(df.columns[:3]) + list(df.columns[-3:])
+    print(tabulate(df[columns].head(rows), maxcolwidths=maxcolwidths, headers=columns, showindex=showindex))
+
+
+
+
+archetypes = [i.strip() for i in "Acquired Capability - Ideation/Simulation,Acquired Capability - Experiences of Endurance,Acquired Capability - Desensitization to Harm,Acquired Capability - High Tolerance for Physical Pain,Acquired Capability - Engagement in Risky Behaviors,Acquired Capability - Familiarity with Self-Harm Methods,Anger,Anhedonia,Availability of means,Aversive Self-awareness,Boredom,Circumstances Less than Expectations,Cognitive deconstruction,Embarassment,Escape,Internal Attributions,Loss/Failure,Medical Conditions,Mental Health,Nihilism,Omnibus Escape Theory,Perceived Burdensomness,Previous Attempts,Social Expectations / Sexuality,Substance Abuse,Unfairness,Thwarted Belongingness".split(",")]
+joiner_three_archs = ['Perceived Burdensomness', 'Thwarted Belongingness', 'Acquired Capability - Ideation/Simulation']
+
+
+def verify_spans_per_user(spans_per_user):
+    for user_id in user2posts:
+        assert user_id in spans_per_user
+        for post in user2posts[user_id]:
+            assert post in spans_per_user[user_id]
+    print("Spans per user passes check")
+
+
+
+def write_submission(top_percentile, score, p, df):
+    spans_per_user = {}
+
+    for user_id, user_posts in TEMPLATE.items():
+        spans_per_user[user_id] = {}
+        user_frame = df[df['user_id'] == int(user_id)]
+        
+        user_post_highlights = user_frame[user_frame.index.isin(top_percentile.index)]
+        if len(user_post_highlights) == 0:
+            spans_per_user[user_id] = {post_object['post_id']:[] for post_object in user_posts['posts']}
+            item = user_frame.sort_values(by=score, ascending=False).iloc[0]
+            post_id = item['post_id']
+            sentence = item['sentence']
+            spans_per_user[user_id][post_id].append(sentence)
+        else:
+            for post_object in user_posts['posts']:
+                post_id = post_object['post_id']
+                post_frame = df[df['post_id'] == post_id]
+                post_highlights = post_frame[post_frame.index.isin(top_percentile.index)]
+                spans_per_user[user_id][post_id] = list(post_highlights.sentence.values)
+
+    verify_spans_per_user(spans_per_user)
+
+    # fill template
+    filled_template = deepcopy(TEMPLATE)
+    for user_id, user_posts in filled_template.items():
+        for post_object in user_posts['posts']:
+            post_id = post_object['post_id']
+            post_object['highlights'] = spans_per_user[user_id][post_id]
+
+    outfile = os.path.join(ARGS.submission_file_path, f"{score}_{p}_submission.json")
+    with open(outfile, "w") as f:
+        #dump spans_per_user to json
+        json.dump(filled_template, f, indent=4)
+    
+    print(f"wrote {outfile}")
+
+
+def reformat_obj(spans_per_user):
+    d = {}
+    for user_id in spans_per_user:
+        d[user_id] = {}
+        for post_object in spans_per_user[user_id]['posts']:
+            d[user_id][post_object['post_id']] = post_object['highlights']
+    return d
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(prog="python span_selection.py", description="Script to explore and decide on a span selection policy and select spans.")
+    parser.add_argument('-s', '--save_df', default=None, type=str, help="Pass in a path to save the df with all the intermediate and final score values.")
+    parser.add_argument('-arc', '--archetypes_sent_file', default=os.path.join(DATADIR, "archetypes_sent.csv"), type=str, help="Path to archetypes sentences file.")    
+    parser.add_argument('-dir', '--sentence_entropy_dir', default=os.path.join(MODELDIR, '_sentence_entropies'), type=str, help="Path to directory that has the sentence entropy files.")
+    parser.add_argument('-te', '--test_group', choices=['any_risk_sw', 'annotations'], default='any_risk_sw', help="This specifies if we're using the internal annotations or the task submission data data.")
+    parser.add_argument('-df', '--sent_df_path', default=None, type=str, help="Path to sentence entropies file. This is an alternative to passing in --sentence_entropy_dir and --test_group.")
+    parser.add_argument('-p', '--percentile_threshold', default=70, type=float)
+    parser.add_argument('-o', '--submission_file_path', default=os.path.join(MODELDIR, '_submission_files'))
+    parser.add_argument('-ml', '--max_output_len', default=100, type=int)
+    parser.add_argument('--num_posts_to_show', default=5, type=int)
+    parser.add_argument('--n_factors', default=1, type=int)
+    parser.add_argument('-w', '--write', action='store_true', default=False)   
+
+    ARGS = parser.parse_args()
+
+    if ARGS.test_group == 'annotations':
+        print('WARNING: Pipeline not fully tested on internal annotations.')
+        template_path = os.path.join(DATADIR, "annotations_template.json")
+    else:
+        template_path = os.path.join(DATADIR, "submission_template.json")
+
+    with open(template_path, 'r') as f:
+        TEMPLATE = json.load(f)
+
+    user2posts = reformat_obj(TEMPLATE)
+
+    if not ARGS.sent_df_path:
+        ARGS.sent_df_path = os.path.join(ARGS.sentence_entropy_dir, f'{ARGS.test_group}_sentence_entropies.json')
+    
+    if ARGS.write:
+        os.makedirs(ARGS.submission_file_path, exist_ok=True)
+    
+
+    main()


### PR DESCRIPTION
## Relative entropy pipeline

All code is in the [relative-entropy](https://github.com/alahnala/clp24-arch-entropy/tree/main/relative-entropy) directory. There is a script that will run the full pipeline: [run_entropy_pipeline.sh](https://github.com/alahnala/clp24-arch-entropy/tree/main/relative-entropy/run_entropy_pipeline.sh) (see steps 0 and 1 below before running it). The section below describes each step.


### Steps

0. Data: This pipeline assumes that the following files are in one directory:
    * clp24_all_messages.csv: This contains all messages from the dataset, including data from the *no risk* users. Prepare it to contain the `label` column with the post authors' risk levels and the `by` (which annotator group) column. For *no risk* users, set the label to "No".
    * clp24_all_messages_test.csv: The messages of the users designated for the test set for the shared task.
    * clp24_all_messages_train.csv: The messages of users not in the test set
    * clp24_SW_messages_sent_tokenized.csv: Sentences from each post in r/SuicideWatch (nltk.sent_tokenize applied to messages).

1. Create a file **config.py** with these contents:

    ```python
    '''config.py'''
    DATADIR = # string pointing to the path of the clpsych24 shared task data, e.g., "/data/clp24/" 
    MODELDIR = # string pointing to a path to a directory where you want to save the finetuning output, e.g., "/data/clp24/finetune-output/"
    ```

2. Prepare dataset for language modeling scripts
    ```bash
    python prepare_data.py
    ```
    * The script will create two files:
        1) DATADIR/all_labels_messages_train.csv
        2) DATADIR/all_labels_messages_test.csv
    * Change where to save the files in the two lines after the imports, if you like.
    * Change the number of no risk posts to include in the test set, if you like. We go with a small sample.

3. Finetune a language model on a group of CLPsych users based on risk level.

    * You are required to specify a group to finetune on. All options follow the format `{Risk level}_risk_{Subreddit set}`. *Risk level* can be no, low, moderate, high, or any (includes low, moderate, and high, but not no risk). *Subreddit set* can be sw (SuicideWatch posts only) or all (all posts by the users in the risk level group)

    
    * Example:
        ```bash
        # example
        python finetune.py --train_group high_risk_sw --model_output_dir data/model_output
        ```
    
    * Usage:
        ```
        Usage: 
        python finetune.py [-h] -g {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all} [-tr ALL_LABELS_MESSAGES_TRAIN] [-d MODEL_OUTPUT_DIR] [-k] [--logging_dir LOGGING_DIR] [--device DEVICE] [-m {distilgpt2}] [-e NUM_EPOCHS] [-lr LEARNING_RATE] [-wd WEIGHT_DECAY] [-ss SAVE_STRATEGY] [-es EVAL_STRATEGY] [--logging_steps LOGGING_STEPS] [--hidden_dropout_prob HIDDEN_DROPOUT_PROB] [--train_proportion TRAIN_PROPORTION]

        Options
            -h, --help
            -g, --train_group {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all}
            -tr ALL_LABELS_MESSAGES_TRAIN, --all_labels_messages_train ALL_LABELS_MESSAGES_TRAIN
                                    Path to training data file.
            -d, --model_output_dir MODEL_OUTPUT_DIR
                                    Directory for saving the model checkpoints. They will be saved at [args.dir]/[args.train_group]. Recommended to make this unique to your experiment.
            -k, --keep_annotations
                                    Pass in -k if you want to include the posts that we annotated internally.
            --logging_dir LOGGING_DIR
                                    Path to a logging dir if you don't want to use the default.
            --device DEVICE
            -m, --base_lm {distilgpt2}
                                    Name of pre-trained language model you want to finetune.
            -e, --num_epochs NUM_EPOCHS
            -lr LEARNING_RATE, --learning_rate LEARNING_RATE
            -wd, --weight_decay WEIGHT_DECAY
            -ss, --save_strategy SAVE_STRATEGY
            -es, --eval_strategy EVAL_STRATEGY
            --logging_steps LOGGING_STEPS
                                    Number of update steps between logs
            --hidden_dropout_prob HIDDEN_DROPOUT_PROB
                                    Dropout
            --train_proportion TRAIN_PROPORTION
                                    Proportion of data to use for train, the rest will be used for eval.
        ```

4. (Optional) Plot losses of the finetuned language models.
    ```bash
    python plot_loss.py 
    ```

    ```
    Options:
        -h, --help            show this help message and exit
        -lm LM_TO_PLOT [LM_TO_PLOT ...], --lm_to_plot LM_TO_PLOT [LM_TO_PLOT ...]
                                Name of the language models you want to plot (i.e. the 'train group'). If passing in nothing, it will do all found LMs in --model_dir path.
        -d, --model_dir MODEL_DIR 
                                Directory where the lms are. Defaults to MODELDIR specified in config.py.
        -o, --plot_path PLOT_PATH
                                Directory where you want to save the plot images. Defaults to MODELDIR/_loss_plots.
    ```


5. Compute token entropies using one group's language model on another group's test data.

    TODO: optimize implementation, current implementation is inefficient

    Example:

    ```bash
    # example

    # compute losses from each group model on their own test data
    python compute_entropy.py --train_group any_risk_sw --test_group any_risk_sw;

    # compute losses from each group model on any risk data
    python compute_entropy.py --train_group no_risk_sw --test_group any_risk_sw;
    ```

    ```
    Options:
        -h, --help            show this help message and exit
        -tr {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all}, --train_group {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all}
                                This specifies the language model that we'll use to compute losses.
        -te {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all,annotations}, --test_group {low_risk_sw,high_risk_sw,moderate_risk_sw,low_risk_all,high_risk_all,moderate_risk_all,no_risk_sw,no_risk_all,any_risk_sw,any_risk_all,annotations}
                                This specifies the data that the language model will be run on for losses.
        -d MODEL_OUTPUT_DIR, --model_output_dir MODEL_OUTPUT_DIR
                                Directory where the finetuned models are saved.
        -o TOKEN_ENTROPIES_DIR, --token_entropies_dir TOKEN_ENTROPIES_DIR
                                Directory path where you want to save the token entropies.
        --all_labels_messages_train ALL_LABELS_MESSAGES_TRAIN
                                Path to training data file.
        --all_labels_messages_test ALL_LABELS_MESSAGES_TEST
                                Path to test data file.
        -m {distilgpt2,lsanochkin/deberta-large-feedback,microsoft/deberta-base}, --base_lm {distilgpt2,lsanochkin/deberta-large-feedback,microsoft/deberta-base}
        -lm {lm,mlm}, --lm_type {lm,mlm}
                                lm: CausalLM | mlm: MaskedLM. Not implemented for mlm yet.
        --device DEVICE
        -sw SW_SIZE, --sw_size SW_SIZE
                                Context window size preceding target token.
        --checkpoint_selection CHECKPOINT_SELECTION
                                Strategy for choosing the model checkpoint to load. Use a) min_eval_loss if you want to choose based on the minimum loss on the val set during training, b) last to use the last checkpoint, or c) a path to
                                the checkpoint directory, e.g., model_dir/train_group/checkpoint-1000.
    ```

6. Map token entropies to sentences. Script aggregates the token entropies at sentence level. Output file by default is {ARGS.test_group}_sentence_entropies.json.

    ```bash
    python sentence_entropy.py
    ```

    ```
    Options:
        -h, --help            show this help message and exit
        -dir TOKEN_ENTROPIES_DIR, --token_entropies_dir TOKEN_ENTROPIES_DIR
                                Directory where you have the token entropies saved.
        -o ARGS.OUTDIR, --ARGS.outdir ARGS.OUTDIR
                                Directory where you want to save the sentence entropies.
        --all_messages ALL_MESSAGES
                                Path to test data file.
        -st SENT_TOKENIZED_FILE, --sent_tokenized_file SENT_TOKENIZED_FILE
                                Path to the data broken into sentences.
        -te {any_risk_sw,annotations}, --test_group {any_risk_sw,annotations}
                                This specifies the data that the language model will be run on for losses.
        -s, --save_intermediate_values
                                Pass in if you want intermediate values to be written to a file.
    ```

7. Explore span selection policies and write submission file with chosen policy. This step may involve your manual changes to the script to adjust your policies or create new ones, but code is written there that will output samples based on your policies.

    ```bash
    python span_selection.py # run with -w if you want to write submission files with the policies implemented in the script.
    ```

8. (optional) Use the compare_systems.py script to compare the highlighted evidence per user from two systems.

    ```bash
    # example
    python compare_systems.py -a max_arch_score_70_submission -b prod_max_arc_ent_ac_70_submission
    ```

    ```
    Options:
        -h, --help            show this help message and exit
        -s SAVE_DF, --save_df SAVE_DF
                                Pass in a path to save the df with all the intermediate and final score values.
        -arc ARCHETYPES_SENT_FILE, --archetypes_sent_file ARCHETYPES_SENT_FILE
                                Path to archetypes sentences file.
        -dir SENTENCE_ENTROPY_DIR, --sentence_entropy_dir SENTENCE_ENTROPY_DIR
                                Path to directory that has the sentence entropy files.
        -te {any_risk_sw,annotations}, --test_group {any_risk_sw,annotations}
                                This specifies if we're using the internal annotations or the task submission data data.
        -df SENT_DF_PATH, --sent_df_path SENT_DF_PATH
                                Path to sentence entropies file. This is an alternative to passing in --sentence_entropy_dir and --test_group.
        -p PERCENTILE_THRESHOLD, --percentile_threshold PERCENTILE_THRESHOLD
        -o SUBMISSION_FILE_PATH, --submission_file_path SUBMISSION_FILE_PATH
        -ml MAX_OUTPUT_LEN, --max_output_len MAX_OUTPUT_LEN
        --num_posts_to_show NUM_POSTS_TO_SHOW
        --n_factors N_FACTORS
        -w, --write
    ```

9. TODO: (optional) Make latex visual of highlighted spans
    